### PR TITLE
add Deriv type to support transpose sugar

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -72,3 +72,4 @@ for T in union(subtypes(DistanceLoss), subtypes(MarginLoss))
 end
 
 end # module
+

--- a/src/supervised/supervised.jl
+++ b/src/supervised/supervised.jl
@@ -19,6 +19,29 @@ end
 end
 
 # --------------------------------------------------------------
+# These non-exported types allow for the convenience syntax
+# `myloss'(y,yhat)` and `myloss''(y,yhat)` without performance
+# penalty
+
+immutable Deriv{L<:SupervisedLoss}
+    loss::L
+end
+
+Base.transpose(loss::SupervisedLoss) = Deriv(loss)
+
+(d::Deriv)(t, y) = deriv(d.loss, t, y)
+(d::Deriv)(x)    = deriv(d.loss, x)
+
+immutable Deriv2{L<:SupervisedLoss}
+    loss::L
+end
+
+Base.transpose(d::Deriv) = Deriv2(d.loss)
+
+(d::Deriv2)(t, y) = deriv2(d.loss, t, y)
+(d::Deriv2)(x)    = deriv2(d.loss, x)
+
+# --------------------------------------------------------------
 # Fallback implementations
 
 isstronglyconvex(::SupervisedLoss) = false


### PR DESCRIPTION
This allows for some syntax abuse that may be nice to have. And it does so without real overhead or the use of closures.

```julia
loss = L2DistLoss()
loss'(y, yhat) # derivative
loss''(y, yhat) # 2nd derivative
```