### PR TITLE
Broadcast implementation and Bugfixes

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -54,11 +54,14 @@ export
 include("common.jl")
 
 include("supervised/supervised.jl")
+include("supervised/sparse.jl")
 include("supervised/distance.jl")
 include("supervised/margin.jl")
 include("supervised/scaledloss.jl")
 include("supervised/other.jl")
 include("supervised/io.jl")
+
+include("deprecate.jl")
 
 # allow using SupervisedLoss as function
 for T in filter(isleaftype,subtypes(SupervisedLoss))

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,0 +1,16 @@
+@deprecate value(loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) value.(loss, targets, outputs)
+@deprecate deriv(loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) deriv.(loss, targets, outputs)
+@deprecate deriv2(loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) deriv2.(loss, targets, outputs)
+
+@deprecate value!(buffer, loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) buffer .= value.(loss, targets, outputs)
+@deprecate deriv!(buffer, loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) buffer .= deriv.(loss, targets, outputs)
+@deprecate deriv2!(buffer, loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) buffer .= deriv2.(loss, targets, outputs)
+
+@deprecate value(loss::SupervisedLoss, array::AbstractArray) value.(loss, array)
+@deprecate deriv(loss::SupervisedLoss, array::AbstractArray) deriv.(loss, array)
+@deprecate deriv2(loss::SupervisedLoss, array::AbstractArray) deriv2.(loss, array)
+
+@deprecate value!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= value.(loss, array)
+@deprecate deriv!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= deriv.(loss, array)
+@deprecate deriv2!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= deriv2.(loss, array)
+

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -14,14 +14,14 @@ end
 LPDistLoss(p::Number) = LPDistLoss{p}()
 
 value{P}(loss::LPDistLoss{P}, difference::Number) = abs(difference)^P
-function deriv{P,T<:Number}(loss::LPDistLoss{P}, difference::T)
+function deriv{P,T<:Number}(loss::LPDistLoss{P}, difference::T)::promote_type(typeof(P),T)
     if difference == 0
         zero(difference)
     else
         P * difference * abs(difference)^(P-convert(typeof(P), 2))
     end
 end
-function deriv2{P,T<:Number}(loss::LPDistLoss{P}, difference::T)
+function deriv2{P,T<:Number}(loss::LPDistLoss{P}, difference::T)::promote_type(typeof(P),T)
     if difference == 0
         zero(difference)
     else
@@ -276,15 +276,7 @@ immutable L1EpsilonInsLoss{T<:AbstractFloat} <: DistanceLoss
 end
 typealias EpsilonInsLoss L1EpsilonInsLoss
 L1EpsilonInsLoss{T<:AbstractFloat}(ε::T) = L1EpsilonInsLoss{T}(ε)
-L1EpsilonInsLoss(ε) = L1EpsilonInsLoss{Float64}(Float64(ε))
-
-function L1EpsilonInsLoss{T<:Number}(ε::T)
-    if T <: AbstractFloat
-        L1EpsilonInsLoss{T}(ε)
-    else # cast to Float64
-        L1EpsilonInsLoss{Float64}(Float64(ε))
-    end
-end
+L1EpsilonInsLoss(ε::Number) = L1EpsilonInsLoss{Float64}(Float64(ε))
 
 function value{T1,T2<:Number}(loss::L1EpsilonInsLoss{T1}, difference::T2)
     T = promote_type(T1,T2)
@@ -292,13 +284,13 @@ function value{T1,T2<:Number}(loss::L1EpsilonInsLoss{T1}, difference::T2)
 end
 function deriv{T1,T2<:Number}(loss::L1EpsilonInsLoss{T1}, difference::T2)
     T = promote_type(T1,T2)
-    abs(difference) <= loss.ε ? zero(T) : sign(difference)
+    abs(difference) <= loss.ε ? zero(T) : T(sign(difference))
 end
 deriv2{T1,T2<:Number}(loss::L1EpsilonInsLoss{T1}, difference::T2) = zero(promote_type(T1,T2))
 function value_deriv{T1,T2<:Number}(loss::L1EpsilonInsLoss{T1}, difference::T2)
     T = promote_type(T1,T2)
     absr = abs(difference)
-    absr <= loss.ε ? (zero(T), zero(T)) : (absr - loss.ε, sign(difference))
+    absr <= loss.ε ? (zero(T), zero(T)) : (absr - loss.ε, T(sign(difference)))
 end
 
 issymmetric(::L1EpsilonInsLoss) = true

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -28,7 +28,6 @@ function deriv2{P,T<:Number}(loss::LPDistLoss{P}, difference::T)
         (abs2(P)-P) * abs(difference)^P / abs2(difference)
     end
 end
-value_deriv{P}(loss::LPDistLoss{P}, difference::Number) = (value(loss,difference), deriv(loss,difference))
 
 isminimizable{P}(::LPDistLoss{P}) = true
 issymmetric{P}(::LPDistLoss{P}) = true
@@ -72,7 +71,6 @@ sumvalue(loss::L1DistLoss, difference::AbstractArray) = sumabs(difference)
 value(loss::L1DistLoss, difference::Number) = abs(difference)
 deriv{T<:Number}(loss::L1DistLoss, difference::T) = convert(T, sign(difference))
 deriv2{T<:Number}(loss::L1DistLoss, difference::T) = zero(T)
-value_deriv(loss::L1DistLoss, difference::Number) = (abs(difference), sign(difference))
 
 isdifferentiable(::L1DistLoss) = false
 isdifferentiable(::L1DistLoss, at) = at != 0
@@ -113,7 +111,6 @@ sumvalue(loss::L2DistLoss, difference::AbstractArray) = sumabs2(difference)
 value(loss::L2DistLoss, difference::Number) = abs2(difference)
 deriv{T<:Number}(loss::L2DistLoss, difference::T) = T(2) * difference
 deriv2{T<:Number}(loss::L2DistLoss, difference::T) = T(2)
-value_deriv{T<:Number}(loss::L2DistLoss, difference::T) = (abs2(difference), T(2) * difference)
 
 isdifferentiable(::L2DistLoss) = true
 isdifferentiable(::L2DistLoss, at) = true
@@ -476,9 +473,6 @@ function deriv{T1, T2 <: Number}(loss::QuantileLoss{T1}, diff::T2)
     T(diff > 0) - loss.τ
 end
 deriv2{T1, T2 <: Number}(::QuantileLoss{T1}, diff::T2) = zero(promote_type(T1, T2))
-function value_deriv{T1, T2 <: Number}(loss::QuantileLoss{T1}, diff::T2)
-    value(loss, diff), deriv(loss, diff)
-end
 
 issymmetric(loss::QuantileLoss) = loss.τ == 0.5
 isdifferentiable(::QuantileLoss) = false
@@ -490,3 +484,4 @@ islipschitzcont_deriv(::QuantileLoss) = true
 isconvex(::QuantileLoss) = true
 isstrictlyconvex(::QuantileLoss) = false
 isstronglyconvex(::QuantileLoss) = false
+

--- a/src/supervised/io.jl
+++ b/src/supervised/io.jl
@@ -2,31 +2,47 @@
 Base.print(io::IO, loss::SupervisedLoss, args...) = print(io, typeof(loss).name.name, args...)
 Base.print(io::IO, loss::L1DistLoss, args...) = print(io, "L1DistLoss", args...)
 Base.print(io::IO, loss::L2DistLoss, args...) = print(io, "L2DistLoss", args...)
-Base.print{P}(io::IO, loss::LPDistLoss{P}, args...) = print(io, typeof(loss).name.name, " with P=$(P)", args...)
-Base.print(io::IO, loss::L1EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with ɛ=$(loss.ε)", args...)
-Base.print(io::IO, loss::L2EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with ɛ=$(loss.ε)", args...)
-Base.print(io::IO, loss::QuantileLoss, args...) = print(io, typeof(loss).name.name, " with τ=$(loss.τ)", args...)
-Base.print(io::IO, loss::SmoothedL1HingeLoss, args...) = print(io, typeof(loss).name.name, " with γ = $(loss.gamma)", args...)
-Base.print(io::IO, loss::PeriodicLoss, args...) = print(io, typeof(loss).name.name, " with circumf=$(round(loss.k / 2π,1))", args...)
+Base.print{P}(io::IO, loss::LPDistLoss{P}, args...) = print(io, typeof(loss).name.name, " with P = $(P)", args...)
+Base.print(io::IO, loss::L1EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with \$\\varepsilon\$ = $(loss.ε)", args...)
+Base.print(io::IO, loss::L2EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with \$\\varepsilon\$ = $(loss.ε)", args...)
+Base.print(io::IO, loss::QuantileLoss, args...) = print(io, typeof(loss).name.name, " with \$\\tau\$ = $(loss.τ)", args...)
+Base.print(io::IO, loss::SmoothedL1HingeLoss, args...) = print(io, typeof(loss).name.name, " with \$\\gamma\$ = $(loss.gamma)", args...)
+Base.print(io::IO, loss::DWDMarginLoss, args...) = print(io, typeof(loss).name.name, " with q = $(loss.q)", args...)
+Base.print(io::IO, loss::PeriodicLoss, args...) = print(io, typeof(loss).name.name, " with circumf = $(round(loss.k / 2π,1))", args...)
 Base.print(io::IO, loss::ScaledLoss, args...) = print(io, typeof(loss).name.name, " $(loss.factor) * [ $(loss.loss) ]", args...)
 
 # -------------------------------------------------------------
 # Plot Recipes
 
-_loss_xguide(loss::MarginLoss) = "y ⋅ h(x)"
+_loss_xguide(loss::MarginLoss) = "y * h(x)"
 _loss_xguide(loss::DistanceLoss) = "h(x) - y"
 
-@recipe function plot(loss::SupervisedLoss, xmin = -2, xmax = 2)
+@recipe function plot(drv::Deriv, rng = -2:0.05:2)
+    xguide --> _loss_xguide(drv.loss)
+    yguide --> "L'(y, h(x))"
+    label  --> string(drv.loss)
+    deriv_fun(drv.loss), rng
+end
+
+@recipe function plot(loss::SupervisedLoss, rng = -2:0.05:2)
     xguide --> _loss_xguide(loss)
     yguide --> "L(y, h(x))"
     label  --> string(loss)
-    value_fun(loss), xmin, xmax
+    value_fun(loss), rng
 end
 
-@recipe function plot{T<:SupervisedLoss}(losses::AbstractVector{T}, xmin = -2, xmax = 2)
+@recipe function plot{T<:Deriv}(derivs::AbstractVector{T}, rng = -2:0.05:2)
+    for drv in derivs
+        @series begin
+            drv, rng
+        end
+    end
+end
+
+@recipe function plot{T<:SupervisedLoss}(losses::AbstractVector{T}, rng = -2:0.05:2)
     for loss in losses
         @series begin
-            loss, xmin, xmax
+            loss, rng
         end
     end
 end

--- a/src/supervised/margin.jl
+++ b/src/supervised/margin.jl
@@ -269,7 +269,6 @@ end
 function deriv2{T<:Number}(loss::SmoothedL1HingeLoss, agreement::T)
     agreement < 1 - loss.gamma || agreement > 1 ? zero(T) : one(T) / loss.gamma
 end
-value_deriv(loss::SmoothedL1HingeLoss, agreement::Number) = (value(loss, agreement), deriv(loss, agreement))
 
 isdifferentiable(::SmoothedL1HingeLoss) = true
 isdifferentiable(::SmoothedL1HingeLoss, at) = true
@@ -322,7 +321,6 @@ end
 function deriv2{T<:Number}(loss::ModifiedHuberLoss, agreement::T)
     agreement < -1 || agreement > 1 ? zero(T) : T(2)
 end
-value_deriv(loss::ModifiedHuberLoss, agreement::Number) = (value(loss, agreement), deriv(loss, agreement))
 
 isdifferentiable(::ModifiedHuberLoss) = true
 isdifferentiable(::ModifiedHuberLoss, at) = true
@@ -365,7 +363,6 @@ immutable L2MarginLoss <: MarginLoss end
 value{T<:Number}(loss::L2MarginLoss, agreement::T) = abs2(one(T) - agreement)
 deriv{T<:Number}(loss::L2MarginLoss, agreement::T) = T(2) * (agreement - one(T))
 deriv2{T<:Number}(loss::L2MarginLoss, agreement::T) = T(2)
-value_deriv{T<:Number}(loss::L2MarginLoss, agreement::T) = (abs2(one(T) - agreement), T(2) * (agreement - one(T)))
 
 isunivfishercons(::L2MarginLoss) = true
 isdifferentiable(::L2MarginLoss) = true
@@ -430,7 +427,6 @@ immutable SigmoidLoss <: MarginLoss end
 value(loss::SigmoidLoss, agreement::Number) = one(agreement) - tanh(agreement)
 deriv(loss::SigmoidLoss, agreement::Number) = -abs2(sech(agreement))
 deriv2{T<:Number}(loss::SigmoidLoss, agreement::T) = T(2) * tanh(agreement) * abs2(sech(agreement))
-value_deriv(loss::SigmoidLoss, agreement::Number) = (one(agreement) - tanh(agreement), -abs2(sech(agreement)))
 
 isunivfishercons(::SigmoidLoss) = true
 isdifferentiable(::SigmoidLoss) = true
@@ -486,8 +482,6 @@ function deriv2{T<:Number}(loss::DWDMarginLoss, agreement::T)
     q = loss.q
     agreement <= q/(q+1) ? zero(Float64) : ( (q^(q+1))/((q+1)^q) ) / agreement^(q+2)
 end
-
-value_deriv(loss::DWDMarginLoss, agreement::Number) = (value(loss, agreement), deriv(loss, agreement))
 
 isdifferentiable(::DWDMarginLoss) = true
 isdifferentiable(::DWDMarginLoss, at) = true

--- a/src/supervised/sparse.jl
+++ b/src/supervised/sparse.jl
@@ -1,0 +1,40 @@
+# Function for sparse arrays
+# value!, deriv!
+# `output` can have more dimensions than `target`, in which case do broadcasting
+
+# TODO: find way to use normal broadcast for this.
+# probably with the new changes in MLMetric and compare modes
+
+
+@inline function value(loss::MarginLoss, target::AbstractSparseArray, output::AbstractArray)
+    buffer = similar(output)
+    value!(buffer, loss, target, output)
+end
+
+##
+@generated function value!{T,N,Q,Ti,M}(
+        buffer::AbstractArray,
+        loss::MarginLoss,
+        target::AbstractSparseArray{Q,Ti,M},
+        output::AbstractArray{T,N}
+    )
+    M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
+    quote
+      @_dimcheck size(buffer) == size(output)
+      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
+      zeroQ = zero(Q)
+      negQ = Q(-1)
+      @simd for I in CartesianRange(size(output))
+          @nexprs $N n->(i_n = I[n])
+          tgt = @nref($M,target,i)
+          if tgt == zeroQ
+              # convention is that zeros in a sparse array are interpreted as negative one
+              @inbounds @nref($N,buffer,i) = value(loss, negQ, @nref($N,output,i))
+          else
+              @inbounds @nref($N,buffer,i) = value(loss, tgt, @nref($N,output,i))
+          end
+      end
+      buffer
+    end
+end
+

--- a/src/supervised/supervised.jl
+++ b/src/supervised/supervised.jl
@@ -172,6 +172,9 @@ function value_deriv(loss::MarginLoss, target::Number, output::Number)
     (v, target*d)
 end
 
+# Fallback for losses that don't want to take advantage of this
+value_deriv(loss::MarginLoss, agreement::Number) = (value(loss, agreement), deriv(loss, agreement))
+
 # TODO: consider meanvalue(loss, agreement) etc
 
 isunivfishercons(::MarginLoss) = false
@@ -195,6 +198,9 @@ value(loss::DistanceLoss, target::Number, output::Number) = value(loss, output -
 deriv(loss::DistanceLoss, target::Number, output::Number) = deriv(loss, output - target)
 deriv2(loss::DistanceLoss, target::Number, output::Number) = deriv2(loss, output - target)
 value_deriv(loss::DistanceLoss, target::Number, output::Number) = value_deriv(loss, output - target)
+
+# Fallback for losses that don't want to take advantage of this
+value_deriv(loss::DistanceLoss, difference::Number) = (value(loss, difference), deriv(loss, difference))
 
 # TODO: consider meanvalue(loss, difference) etc
 

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -1,3 +1,38 @@
+function test_vector_value(l::MarginLoss, t, y)
+    @testset "$(l): " begin
+        ref = [ LossFunctions.value(l,t[i],y[i]) for i in 1:length(y) ]
+        @test LossFunctions.value.(l, t, y) == ref
+        @test LossFunctions.value.(l, t .* y) == ref
+        @test l.(t, y) == ref
+        @test l.(t .* y) == ref
+    end
+end
+
+function test_vector_value(l::DistanceLoss, t, y)
+    @testset "$(l): " begin
+        ref = [ LossFunctions.value(l,t[i],y[i]) for i in 1:length(y) ]
+        @test LossFunctions.value.(l, t, y) == ref
+        @test LossFunctions.value.(l, y - t) == ref
+        @test l.(t, y) == ref
+        @test l.(y - t) == ref
+    end
+end
+
+@testset "Vectorized API" begin
+    targets = rand([-1,1], 10)
+    outputs = (rand(10)-.5) * 20
+
+    for loss in margin_losses
+        test_vector_value(loss, targets, outputs)
+    end
+
+    targets = (rand(10)-.5) * 20
+    outputs = (rand(10)-.5) * 20
+    for loss in distance_losses
+        test_vector_value(loss, targets, outputs)
+    end
+end
+
 @testset "Broadcasting higher-order arrays" begin
     for f in (LossFunctions.value,deriv,sumvalue,sumderiv,meanvalue,meanderiv)
         @testset "$f" begin
@@ -16,9 +51,7 @@
             @test isapprox(f(loss,targ1,out2), f(loss,targ2,out2))
             @test isapprox(f(loss,targ1,out2), f(loss,targ3,out2))
             @test isapprox(f(loss,targ2,out2), f(loss,targ3,out2))
-
-            # can't broadcast in this direction (yet)
-            @test_throws Exception f(loss,targ3,out1)
         end
     end
 end
+

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -18,18 +18,62 @@ function test_vector_value(l::DistanceLoss, t, y)
     end
 end
 
+function test_vector_deriv(l::MarginLoss, t, y)
+    @testset "$(l): " begin
+        ref = [ LossFunctions.deriv(l,t[i],y[i]) for i in 1:length(y) ]
+        @test LossFunctions.deriv.(l, t, y) == ref
+        @test t .* LossFunctions.deriv.(l, t .* y) == ref
+        @test l'.(t, y) == ref
+        @test t .* l'.(t .* y) == ref
+    end
+end
+
+function test_vector_deriv(l::DistanceLoss, t, y)
+    @testset "$(l): " begin
+        ref = [ LossFunctions.deriv(l,t[i],y[i]) for i in 1:length(y) ]
+        @test LossFunctions.deriv.(l, t, y) == ref
+        @test LossFunctions.deriv.(l, y - t) == ref
+        @test l'.(t, y) == ref
+        @test l'.(y - t) == ref
+    end
+end
+
+function test_vector_deriv2(l::MarginLoss, t, y)
+    @testset "$(l): " begin
+        ref = [ LossFunctions.deriv2(l,t[i],y[i]) for i in 1:length(y) ]
+        @test LossFunctions.deriv2.(l, t, y) == ref
+        @test LossFunctions.deriv2.(l, t .* y) == ref
+        @test l''.(t, y) == ref
+        @test l''.(t .* y) == ref
+    end
+end
+
+function test_vector_deriv2(l::DistanceLoss, t, y)
+    @testset "$(l): " begin
+        ref = [ LossFunctions.deriv2(l,t[i],y[i]) for i in 1:length(y) ]
+        @test LossFunctions.deriv2.(l, t, y) == ref
+        @test LossFunctions.deriv2.(l, y - t) == ref
+        @test l''.(t, y) == ref
+        @test l''.(y - t) == ref
+    end
+end
+
 @testset "Vectorized API" begin
     targets = rand([-1,1], 10)
     outputs = (rand(10)-.5) * 20
 
     for loss in margin_losses
         test_vector_value(loss, targets, outputs)
+        test_vector_deriv(loss, targets, outputs)
+        test_vector_deriv2(loss, targets, outputs)
     end
 
     targets = (rand(10)-.5) * 20
     outputs = (rand(10)-.5) * 20
     for loss in distance_losses
         test_vector_value(loss, targets, outputs)
+        test_vector_deriv(loss, targets, outputs)
+        test_vector_deriv2(loss, targets, outputs)
     end
 end
 

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -270,12 +270,14 @@ end
     test_value_float64_forcing(2.0 * SigmoidLoss())
 
     # Losses that should return an AbstractFloat, preserving type if possible
-    for loss in [PeriodicLoss(Float32(1)), PeriodicLoss(Float32(0.5)),
+    for loss in [SmoothedL1HingeLoss(0.5f0), SmoothedL1HingeLoss(1f0),
+                 PeriodicLoss(1f0), PeriodicLoss(0.5f0),
                  LogitDistLoss(), LogitMarginLoss(), ExpLoss(), SigmoidLoss(),
-                 L1EpsilonInsLoss(Float32(1)), L1EpsilonInsLoss(Float32(0.5)),
-                 L2EpsilonInsLoss(Float32(1)), L2EpsilonInsLoss(Float32(0.5))]
+                 L1EpsilonInsLoss(1f0), L1EpsilonInsLoss(0.5f0),
+                 L2EpsilonInsLoss(1f0), L2EpsilonInsLoss(0.5f0),
+                 HuberLoss(1.0f0), QuantileLoss(.8f0), DWDMarginLoss(0.5f0)]
         test_value_float32_preserving(loss)
-        test_value_float32_preserving(Float32(2) * loss)
+        test_value_float32_preserving(2f0 * loss)
     end
 end
 

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -2,6 +2,10 @@ function test_value_typestable(l::SupervisedLoss)
     @testset "$(l): " begin
         for y in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
             for t in (-2, 2, Int32(-1), Int32(1), -.5, .5, Float32(-1), Float32(1))
+                # check inference
+                @inferred deriv(l, y, t)
+                @inferred deriv2(l, y, t)
+
                 # get expected return type
                 T = promote_type(typeof(y), typeof(t))
 
@@ -20,6 +24,10 @@ function test_value_float32_preserving(l::SupervisedLoss)
     @testset "$(l): " begin
         for y in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
             for t in (-2, 2, Int32(-1), Int32(1), -.5, .5, Float32(-1), Float32(1))
+                # check inference
+                @inferred deriv(l, y, t)
+                @inferred deriv2(l, y, t)
+
                 val = @inferred LossFunctions.value(l, y, t)
                 T = promote_type(typeof(y),typeof(t))
                 if !(T <: AbstractFloat)
@@ -41,6 +49,10 @@ function test_value_float64_forcing(l::SupervisedLoss)
     @testset "$(l): " begin
         for y in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
             for t in (-2, 2, Int32(-1), Int32(1), -.5, .5, Float32(-1), Float32(1))
+                # check inference
+                @inferred deriv(l, y, t)
+                @inferred deriv2(l, y, t)
+
                 val = @inferred LossFunctions.value(l, y, t)
                 @test (typeof(val) <: Float64)
             end

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -479,7 +479,7 @@ end
         output = randn(N)
 
         for loss in margin_losses
-            @test isapprox(@inferred(LossFunctions.value(loss,sparse_target,output)), LossFunctions.value(loss,target,output))
+            @test isapprox(@inferred(LossFunctions.value(loss,sparse_target,output)), LossFunctions.value.(loss,target,output))
         end
     end
 
@@ -498,7 +498,7 @@ end
         output = randn(N,N)
 
         for loss in margin_losses
-            @test isapprox(@inferred(LossFunctions.value(loss,sparse_target,output)), LossFunctions.value(loss,target,output))
+            @test isapprox(@inferred(LossFunctions.value(loss,sparse_target,output)), LossFunctions.value.(loss,target,output))
         end
     end
 end


### PR DESCRIPTION
Refactors the vectorized methods to use new broadcast sugar

Other Fixes:

- don't require losses to  implement `value_deriv` if they just wrap `value` and `deriv` anyway
- Type stability issues of deriv
- Type restrictions for some Losses
- unimplemented vectorization for some signatures
- better plots recipes

