### PR TITLE
refactor ScaledLoss to use type parameter. fixes #55

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -49,7 +49,8 @@ export
     CrossentropyLoss,
     ZeroOneLoss,
 
-    ScaledLoss
+    ScaledLoss,
+    scaledloss
 
 include("common.jl")
 

--- a/src/supervised/io.jl
+++ b/src/supervised/io.jl
@@ -3,14 +3,14 @@ Base.print(io::IO, loss::SupervisedLoss, args...) = print(io, typeof(loss).name.
 Base.print(io::IO, loss::L1DistLoss, args...) = print(io, "L1DistLoss", args...)
 Base.print(io::IO, loss::L2DistLoss, args...) = print(io, "L2DistLoss", args...)
 Base.print{P}(io::IO, loss::LPDistLoss{P}, args...) = print(io, typeof(loss).name.name, " with P = $(P)", args...)
-Base.print(io::IO, loss::L1EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with \$\\varepsilon\$ = $(loss.ε)", args...)
-Base.print(io::IO, loss::L2EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with \$\\varepsilon\$ = $(loss.ε)", args...)
+Base.print(io::IO, loss::L1EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with \$\\epsilon\$ = $(loss.ε)", args...)
+Base.print(io::IO, loss::L2EpsilonInsLoss, args...) = print(io, typeof(loss).name.name, " with \$\\epsilon\$ = $(loss.ε)", args...)
 Base.print(io::IO, loss::QuantileLoss, args...) = print(io, typeof(loss).name.name, " with \$\\tau\$ = $(loss.τ)", args...)
 Base.print(io::IO, loss::SmoothedL1HingeLoss, args...) = print(io, typeof(loss).name.name, " with \$\\gamma\$ = $(loss.gamma)", args...)
 Base.print(io::IO, loss::HuberLoss, args...) = print(io, typeof(loss).name.name, " with \$\\alpha\$ = $(loss.d)", args...)
 Base.print(io::IO, loss::DWDMarginLoss, args...) = print(io, typeof(loss).name.name, " with q = $(loss.q)", args...)
 Base.print(io::IO, loss::PeriodicLoss, args...) = print(io, typeof(loss).name.name, " with c = $(round(2π / loss.k,1))", args...)
-Base.print(io::IO, loss::ScaledLoss, args...) = print(io, typeof(loss).name.name, " $(loss.factor) * [ $(loss.loss) ]", args...)
+Base.print{T,K}(io::IO, loss::ScaledLoss{T,K}, args...) = print(io, "$(K) * ($(loss.loss))", args...)
 
 # -------------------------------------------------------------
 # Plot Recipes

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -213,7 +213,8 @@ end
 function test_scaledloss(l::Loss, t_vec, y_vec)
     @testset "Scaling for $(l): " begin
         for λ = (2.0, 2)
-            sl = ScaledLoss(l,λ)
+            sl = scaledloss(l,λ)
+            @test sl == @inferred(scaledloss(l,Val{λ}))
             @test sl == λ * l
             for t in t_vec
                 for y in y_vec
@@ -232,7 +233,8 @@ end
 function test_scaledloss(l::Loss, n_vec)
     @testset "Scaling for $(l): " begin
         for λ = (2.0, 2)
-            sl = ScaledLoss(l,λ)
+            sl = scaledloss(l,λ)
+            @test sl == @inferred(scaledloss(l,Val{λ}))
             @test sl == λ * l
             for n in n_vec
                 @test LossFunctions.value(sl,n) == @inferred(sl(n))
@@ -470,11 +472,17 @@ end
     end
 end
 
+typealias FooLoss LossFunctions.ScaledDistanceLoss{L2EpsilonInsLoss,2}
+
 @testset "Test distance-based scaled loss" begin
     for loss in distance_losses
         test_scaledloss(loss, -20:.2:20, -20:0.5:20)
         test_scaledloss(loss, -20:0.5:20)
     end
+
+    l = @inferred FooLoss(1.2)
+    @test l.loss == L2EpsilonInsLoss(1.2)
+    @test l(7.2) == 2 * l.loss(7.2)
 end
 
 @testset "Test sparse array conventions for margin-based losses" begin


### PR DESCRIPTION
This makes this works:

```julia
typealias LeastSquaresLoss LossFunctions.ScaledDistanceLoss{L2DistLoss,0.5}
@assert LeastSquaresLoss <: DistanceLoss
LeastSquaresLoss()

typealias ScEpsLoss LossFunctions.ScaledDistanceLoss{L1EpsilonInsLoss,0.5}
ScEpsLoss(3) # passes epsilon to the constructor of inner loss
```

Should make your code a bit nicer @joshday 