### PR TITLE
WIP: Outline new average mode

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -57,8 +57,6 @@ export
 include("common.jl")
 include("averagemode.jl")
 
-typealias Mean Union{AvgMode.Macro,AvgMode.Micro}
-
 include("supervised/supervised.jl")
 include("supervised/sparse.jl")
 include("supervised/distance.jl")

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -50,9 +50,14 @@ export
     ZeroOneLoss,
 
     weightedloss,
-    scaledloss
+    scaledloss,
+
+    AvgMode
 
 include("common.jl")
+include("averagemode.jl")
+
+typealias Mean Union{AvgMode.Macro,AvgMode.Micro}
 
 include("supervised/supervised.jl")
 include("supervised/sparse.jl")
@@ -66,18 +71,17 @@ include("supervised/io.jl")
 include("deprecate.jl")
 
 # allow using some special losses as function
-(loss::ScaledSupervisedLoss)(target, output) = value(loss, target, output)
-(loss::WeightedBinaryLoss)(target, output) = value(loss, target, output)
+(loss::ScaledSupervisedLoss)(args...) = value(loss, args...)
+(loss::WeightedBinaryLoss)(args...)   = value(loss, args...)
 
 # allow using SupervisedLoss as function
-for T in filter(isleaftype,subtypes(SupervisedLoss))
-    @eval (loss::$T)(target, output) = value(loss, target, output)
+for T in filter(isleaftype, subtypes(SupervisedLoss))
+    @eval (loss::$T)(args...) = value(loss, args...)
 end
 
 # allow using MarginLoss and DistanceLoss as function
 for T in union(subtypes(DistanceLoss), subtypes(MarginLoss))
-    @eval (loss::$T)(target, output) = value(loss, target, output)
-    @eval (loss::$T)(x) = value(loss, x)
+    @eval (loss::$T)(args...) = value(loss, args...)
 end
 
 end # module

--- a/src/averagemode.jl
+++ b/src/averagemode.jl
@@ -11,16 +11,28 @@ module AvgMode
         Mean,
         Macro,
         Micro,
-        Weighted
+        WeightedMean,
+        WeightedSum
 
     immutable None <: AverageMode end
     immutable Sum <: AverageMode end
     immutable Macro <: AverageMode end
-    immutable Micro <: AverageMode end
-    immutable Weighted{T<:WeightVec} <: AverageMode
+    immutable Mean <: AverageMode end
+    typealias Micro Mean
+
+    immutable WeightedMean{T<:WeightVec} <: AverageMode
         weights::T
+        normalize::Bool
     end
-    Weighted(A::AbstractVector) = Weighted(weights(A))
+    WeightedMean(A::AbstractVector, normalize::Bool) = WeightedMean(weights(A), normalize)
+    WeightedMean(A::AbstractVector; normalize::Bool = true) = WeightedMean(weights(A), normalize)
+
+    immutable WeightedSum{T<:WeightVec} <: AverageMode
+        weights::T
+        normalize::Bool
+    end
+    WeightedSum(A::AbstractVector, normalize::Bool) = WeightedSum(weights(A), normalize)
+    WeightedSum(A::AbstractVector; normalize::Bool = true) = WeightedSum(weights(A), normalize)
 
 end
 

--- a/src/averagemode.jl
+++ b/src/averagemode.jl
@@ -1,0 +1,26 @@
+abstract AverageMode
+
+module AvgMode
+
+    using StatsBase
+    import ..LossFunctions.AverageMode
+
+    export
+        None,
+        Sum,
+        Mean,
+        Macro,
+        Micro,
+        Weighted
+
+    immutable None <: AverageMode end
+    immutable Sum <: AverageMode end
+    immutable Macro <: AverageMode end
+    immutable Micro <: AverageMode end
+    immutable Weighted{T<:WeightVec} <: AverageMode
+        weights::T
+    end
+    Weighted(A::AbstractVector) = Weighted(weights(A))
+
+end
+

--- a/src/common.jl
+++ b/src/common.jl
@@ -5,6 +5,6 @@ macro _not_implemented()
 end
 
 macro _dimcheck(condition)
-    :(($(esc(condition))) || throw(DimensionMismatch("Dimensions of the parameters don't match")))
+    :(($(esc(condition))) || throw(DimensionMismatch("Dimensions of the parameters don't match: $($(string(condition)))")))
 end
 

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -1,14 +1,6 @@
-@deprecate value(loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) value.(loss, targets, outputs)
-@deprecate deriv(loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) deriv.(loss, targets, outputs)
-@deprecate deriv2(loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) deriv2.(loss, targets, outputs)
-
 @deprecate value!(buffer, loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) buffer .= value.(loss, targets, outputs)
 @deprecate deriv!(buffer, loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) buffer .= deriv.(loss, targets, outputs)
 @deprecate deriv2!(buffer, loss::SupervisedLoss, targets::AbstractArray, outputs::AbstractArray) buffer .= deriv2.(loss, targets, outputs)
-
-@deprecate value(loss::SupervisedLoss, array::AbstractArray) value.(loss, array)
-@deprecate deriv(loss::SupervisedLoss, array::AbstractArray) deriv.(loss, array)
-@deprecate deriv2(loss::SupervisedLoss, array::AbstractArray) deriv2.(loss, array)
 
 @deprecate value!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= value.(loss, array)
 @deprecate deriv!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= deriv.(loss, array)

--- a/src/deprecate.jl
+++ b/src/deprecate.jl
@@ -6,3 +6,8 @@
 @deprecate deriv!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= deriv.(loss, array)
 @deprecate deriv2!(buffer, loss::SupervisedLoss, array::AbstractArray) buffer .= deriv2.(loss, array)
 
+@deprecate sumvalue(loss::SupervisedLoss, targets, outputs) value(loss, targets, outputs, AvgMode.Sum())
+@deprecate sumderiv(loss::SupervisedLoss, targets, outputs) deriv(loss, targets, outputs, AvgMode.Sum())
+@deprecate meanvalue(loss::SupervisedLoss, targets, outputs) value(loss, targets, outputs, AvgMode.Mean())
+@deprecate meanderiv(loss::SupervisedLoss, targets, outputs) deriv(loss, targets, outputs, AvgMode.Mean())
+

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -113,7 +113,6 @@ It is strictly convex.
 """
 typealias L2DistLoss LPDistLoss{2}
 
-sumvalue(loss::L2DistLoss, difference::AbstractArray) = sumabs2(difference)
 value(loss::L2DistLoss, difference::Number) = abs2(difference)
 deriv{T<:Number}(loss::L2DistLoss, difference::T) = T(2) * difference
 deriv2{T<:Number}(loss::L2DistLoss, difference::T) = T(2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,25 @@ perf = [
 # for deterministic testing
 srand(1234)
 
+distance_losses = [
+    L2DistLoss(), LPDistLoss(2.0), L1DistLoss(), LPDistLoss(1.0),
+    LPDistLoss(0.5), LPDistLoss(1.5), LPDistLoss(3),
+    LogitDistLoss(), L1EpsilonInsLoss(0.5), EpsilonInsLoss(1.5),
+    L2EpsilonInsLoss(0.5), L2EpsilonInsLoss(1.5),
+    PeriodicLoss(1), PeriodicLoss(1.5), HuberLoss(1),
+    HuberLoss(1.5), QuantileLoss(.2), QuantileLoss(.5),
+    QuantileLoss(.8)
+]
+
+margin_losses = [
+    LogitMarginLoss(), L1HingeLoss(), L2HingeLoss(),
+    PerceptronLoss(), SmoothedL1HingeLoss(.5),
+    SmoothedL1HingeLoss(1), SmoothedL1HingeLoss(2),
+    ModifiedHuberLoss(), ZeroOneLoss(), L2MarginLoss(),
+    ExpLoss(), SigmoidLoss(), DWDMarginLoss(.5),
+    DWDMarginLoss(1), DWDMarginLoss(2)
+]
+
 for t in tests
     @testset "$t" begin
         include(t)

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -1,84 +1,288 @@
 function test_vector_value(l::MarginLoss, t, y)
-    @testset "$(l): " begin
-        ref = [ LossFunctions.value(l,t[i],y[i]) for i in 1:length(y) ]
-        @test LossFunctions.value.(l, t, y) == ref
-        @test LossFunctions.value.(l, t .* y) == ref
-        @test l.(t, y) == ref
-        @test l.(t .* y) == ref
+    ref = [LossFunctions.value(l,t[i],y[i]) for i in CartesianRange(size(y))]
+    yt = t .* y
+    buf = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf, l, t, y)) == ref
+    @test buf == ref
+    buf1 = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf1, l, yt)) == ref
+    @test buf1 == ref
+    buf2 = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf2, l, t, y, AvgMode.None())) == ref
+    @test buf2 == ref
+    buf3 = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf3, l, yt, AvgMode.None())) == ref
+    @test buf3 == ref
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.value(l, t, y)) == ref
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.value(l, yt)) == ref
+    @test LossFunctions.value.(l, t, y) == ref
+    @test LossFunctions.value.(l, yt) == ref
+    @test @inferred(l(t, y, AvgMode.None())) == ref
+    @test @inferred(l(t, y)) == ref
+    @test @inferred(l(yt, AvgMode.None())) == ref
+    @test @inferred(l(yt)) == ref
+    @test l.(t, y) == ref
+    @test l.(yt) == ref
+    # Sum
+    s = sum(ref)
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.Sum())) ≈ s
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.Sum())) ≈ s
+    @test @inferred(l(t, y, AvgMode.Sum())) ≈ s
+    @test @inferred(l(yt, AvgMode.Sum())) ≈ s
+    # Mean
+    m = mean(ref)
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.Mean())) ≈ m
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.Mean())) ≈ m
+    @test @inferred(l(t, y, AvgMode.Mean())) ≈ m
+    @test @inferred(l(yt, AvgMode.Mean())) ≈ m
+    # Obs specific
+    n = size(t, 1)
+    k = size(t, ndims(t))
+    ## Weighted Mean
+    @test_throws DimensionMismatch LossFunctions.value(l, t, y, AvgMode.WeightedMean(ones(n-1)), ObsDim.First())
+    @test_throws DimensionMismatch LossFunctions.value(l, yt, AvgMode.WeightedMean(ones(n-1)), ObsDim.First())
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedMean(ones(n)), ObsDim.First())) ≈ m
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedMean(ones(n)), ObsDim.First())) ≈ m
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedMean(ones(k)), ObsDim.Last())) ≈ m
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedMean(ones(k)), ObsDim.Last())) ≈ m
+    ## Weighted Sum
+    @test_throws DimensionMismatch LossFunctions.value(l, t, y, AvgMode.WeightedSum(ones(n-1)), ObsDim.First())
+    @test_throws DimensionMismatch LossFunctions.value(l, yt, AvgMode.WeightedSum(ones(n-1)), ObsDim.First())
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(ones(n),normalize=false), ObsDim.First())) ≈ s
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(ones(n),normalize=false), ObsDim.First())) ≈ s
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(ones(k),normalize=false), ObsDim.Last())) ≈ s
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(ones(k),normalize=false), ObsDim.Last())) ≈ s
+    if typeof(t) <: AbstractVector
+        @test_throws ArgumentError LossFunctions.value(l, t, y, AvgMode.Sum(), ObsDim.First())
+        @test_throws ArgumentError LossFunctions.value(l, t, y, AvgMode.Mean(), ObsDim.First())
+    else
+        # Sum per obs
+        sv = vec(sum(ref, 1:(ndims(ref)-1)))
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        buffer1 = zeros(sv)
+        @test @inferred(LossFunctions.value!(buffer1, l, t, y, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        @test buffer1 ≈ sv
+        buffer2 = zeros(sv)
+        @test @inferred(LossFunctions.value!(buffer2, l, yt, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        @test buffer2 ≈ sv
+        # Weighted sum compare
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(1:k,normalize=false), ObsDim.Last())) ≈ sum(sv .* (1:k))
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(1:k,normalize=false), ObsDim.Last())) ≈ sum(sv .* (1:k))
+        @test round(@inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(1:k), ObsDim.Last())),3) ≈ round(sum(sv .* ((1:k)/(sum(1:k)))),3)
+        @test round(@inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(1:k), ObsDim.Last())),3) ≈ round(sum(sv .* ((1:k)/(sum(1:k)))),3)
+        # Mean per obs
+        mv = vec(mean(ref, 1:(ndims(ref)-1)))
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        buffer3 = zeros(mv)
+        @test @inferred(LossFunctions.value!(buffer3, l, t, y, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        @test buffer3 ≈ mv
+        buffer4 = zeros(mv)
+        @test @inferred(LossFunctions.value!(buffer4, l, yt, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        @test buffer4 ≈ mv
+        # Weighted mean compare
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedMean(1:k,normalize=false), ObsDim.Last())) ≈ sum(mv .* (1:k))
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedMean(1:k,normalize=false), ObsDim.Last())) ≈ sum(mv .* (1:k))
     end
 end
 
 function test_vector_value(l::DistanceLoss, t, y)
-    @testset "$(l): " begin
-        ref = [ LossFunctions.value(l,t[i],y[i]) for i in 1:length(y) ]
-        @test LossFunctions.value.(l, t, y) == ref
-        @test LossFunctions.value.(l, y - t) == ref
-        @test l.(t, y) == ref
-        @test l.(y - t) == ref
+    ref = [LossFunctions.value(l,t[i],y[i]) for i in CartesianRange(size(y))]
+    yt = y .- t
+    buf = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf, l, t, y)) == ref
+    @test buf == ref
+    buf1 = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf1, l, yt)) == ref
+    @test buf1 == ref
+    buf2 = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf2, l, t, y, AvgMode.None())) == ref
+    @test buf2 == ref
+    buf3 = zeros(ref)
+    @test @inferred(LossFunctions.value!(buf3, l, yt, AvgMode.None())) == ref
+    @test buf3 == ref
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.value(l, t, y)) == ref
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.value(l, yt)) == ref
+    @test LossFunctions.value.(l, t, y) == ref
+    @test LossFunctions.value.(l, yt) == ref
+    @test @inferred(l(t, y, AvgMode.None())) == ref
+    @test @inferred(l(t, y)) == ref
+    @test @inferred(l(yt, AvgMode.None())) == ref
+    @test @inferred(l(yt)) == ref
+    @test l.(t, y) == ref
+    @test l.(yt) == ref
+    # Sum
+    s = sum(ref)
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.Sum())) ≈ s
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.Sum())) ≈ s
+    @test @inferred(l(t, y, AvgMode.Sum())) ≈ s
+    @test @inferred(l(yt, AvgMode.Sum())) ≈ s
+    # Mean
+    m = mean(ref)
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.Mean())) ≈ m
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.Mean())) ≈ m
+    @test @inferred(l(t, y, AvgMode.Mean())) ≈ m
+    @test @inferred(l(yt, AvgMode.Mean())) ≈ m
+    # Obs specific
+    n = size(t, 1)
+    k = size(t, ndims(t))
+    ## Weighted Mean
+    @test_throws DimensionMismatch LossFunctions.value(l, t, y, AvgMode.WeightedMean(ones(n-1)), ObsDim.First())
+    @test_throws DimensionMismatch LossFunctions.value(l, yt, AvgMode.WeightedMean(ones(n-1)), ObsDim.First())
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedMean(ones(n)), ObsDim.First())) ≈ m
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedMean(ones(n)), ObsDim.First())) ≈ m
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedMean(ones(k)), ObsDim.Last())) ≈ m
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedMean(ones(k)), ObsDim.Last())) ≈ m
+    ## Weighted Sum
+    @test_throws DimensionMismatch LossFunctions.value(l, t, y, AvgMode.WeightedSum(ones(n-1)), ObsDim.First())
+    @test_throws DimensionMismatch LossFunctions.value(l, yt, AvgMode.WeightedSum(ones(n-1)), ObsDim.First())
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(ones(n),normalize=false), ObsDim.First())) ≈ s
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(ones(n),normalize=false), ObsDim.First())) ≈ s
+    @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(ones(k),normalize=false), ObsDim.Last())) ≈ s
+    @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(ones(k),normalize=false), ObsDim.Last())) ≈ s
+    if typeof(t) <: AbstractVector
+        @test_throws ArgumentError LossFunctions.value(l, t, y, AvgMode.Sum(), ObsDim.First())
+        @test_throws ArgumentError LossFunctions.value(l, t, y, AvgMode.Mean(), ObsDim.First())
+    else
+        # Sum per obs
+        sv = vec(sum(ref, 1:(ndims(ref)-1)))
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        buffer1 = zeros(sv)
+        @test @inferred(LossFunctions.value!(buffer1, l, t, y, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        @test buffer1 ≈ sv
+        buffer2 = zeros(sv)
+        @test @inferred(LossFunctions.value!(buffer2, l, yt, AvgMode.Sum(), ObsDim.Last())) ≈ sv
+        @test buffer2 ≈ sv
+        # Weighted sum compare
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedSum(1:k,normalize=false), ObsDim.Last())) ≈ sum(sv .* (1:k))
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedSum(1:k,normalize=false), ObsDim.Last())) ≈ sum(sv .* (1:k))
+        # Mean per obs
+        mv = vec(mean(ref, 1:(ndims(ref)-1)))
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        buffer3 = zeros(mv)
+        @test @inferred(LossFunctions.value!(buffer3, l, t, y, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        @test buffer3 ≈ mv
+        buffer4 = zeros(mv)
+        @test @inferred(LossFunctions.value!(buffer4, l, yt, AvgMode.Mean(), ObsDim.Last())) ≈ mv
+        @test buffer4 ≈ mv
+        # Weighted mean compare
+        @test @inferred(LossFunctions.value(l, t, y, AvgMode.WeightedMean(1:k,normalize=false), ObsDim.Last())) ≈ sum(mv .* (1:k))
+        @test @inferred(LossFunctions.value(l, yt, AvgMode.WeightedMean(1:k,normalize=false), ObsDim.Last())) ≈ sum(mv .* (1:k))
     end
 end
 
 function test_vector_deriv(l::MarginLoss, t, y)
-    @testset "$(l): " begin
-        ref = [ LossFunctions.deriv(l,t[i],y[i]) for i in 1:length(y) ]
-        @test LossFunctions.deriv.(l, t, y) == ref
-        @test t .* LossFunctions.deriv.(l, t .* y) == ref
-        @test l'.(t, y) == ref
-        @test t .* l'.(t .* y) == ref
-    end
+    ref = [LossFunctions.deriv(l,t[i],y[i]) for i in CartesianRange(size(y))]
+    yt = t .* y
+    @test @inferred(LossFunctions.deriv(l, t, y, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv(l, t, y)) == ref
+    @test t .* @inferred(LossFunctions.deriv(l, yt, AvgMode.None())) == ref
+    @test t .* @inferred(LossFunctions.deriv(l, yt)) == ref
+    @test LossFunctions.deriv.(l, t, y) == ref
+    @test t .* LossFunctions.deriv.(l, yt) == ref
+    @test @inferred(l'(t, y, AvgMode.None())) == ref
+    @test @inferred(l'(t, y)) == ref
+    @test t .* @inferred(l'(yt, AvgMode.None())) == ref
+    @test t .* @inferred(l'(yt)) == ref
+    @test l'.(t, y) == ref
+    @test t .* l'.(yt) == ref
 end
 
 function test_vector_deriv(l::DistanceLoss, t, y)
-    @testset "$(l): " begin
-        ref = [ LossFunctions.deriv(l,t[i],y[i]) for i in 1:length(y) ]
-        @test LossFunctions.deriv.(l, t, y) == ref
-        @test LossFunctions.deriv.(l, y - t) == ref
-        @test l'.(t, y) == ref
-        @test l'.(y - t) == ref
-    end
+    ref = [LossFunctions.deriv(l,t[i],y[i]) for i in CartesianRange(size(y))]
+    yt = y .- t
+    @test @inferred(LossFunctions.deriv(l, t, y, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv(l, t, y)) == ref
+    @test @inferred(LossFunctions.deriv(l, yt, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv(l, yt)) == ref
+    @test LossFunctions.deriv.(l, t, y) == ref
+    @test LossFunctions.deriv.(l, yt) == ref
+    @test @inferred(l'(t, y, AvgMode.None())) == ref
+    @test @inferred(l'(t, y)) == ref
+    @test @inferred(l'(yt, AvgMode.None())) == ref
+    @test @inferred(l'(yt)) == ref
+    @test l'.(t, y) == ref
+    @test l'.(yt) == ref
 end
 
 function test_vector_deriv2(l::MarginLoss, t, y)
-    @testset "$(l): " begin
-        ref = [ LossFunctions.deriv2(l,t[i],y[i]) for i in 1:length(y) ]
-        @test LossFunctions.deriv2.(l, t, y) == ref
-        @test LossFunctions.deriv2.(l, t .* y) == ref
-        @test l''.(t, y) == ref
-        @test l''.(t .* y) == ref
-    end
+    ref = [LossFunctions.deriv2(l,t[i],y[i]) for i in CartesianRange(size(y))]
+    yt = t .* y
+    @test @inferred(LossFunctions.deriv2(l, t, y, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv2(l, t, y)) == ref
+    @test @inferred(LossFunctions.deriv2(l, yt, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv2(l, yt)) == ref
+    @test LossFunctions.deriv2.(l, t, y) == ref
+    @test LossFunctions.deriv2.(l, yt) == ref
+    @test @inferred(l''(t, y, AvgMode.None())) == ref
+    @test @inferred(l''(t, y)) == ref
+    @test @inferred(l''(yt, AvgMode.None())) == ref
+    @test @inferred(l''(yt)) == ref
+    @test l''.(t, y) == ref
+    @test l''.(yt) == ref
 end
 
 function test_vector_deriv2(l::DistanceLoss, t, y)
-    @testset "$(l): " begin
-        ref = [ LossFunctions.deriv2(l,t[i],y[i]) for i in 1:length(y) ]
-        @test LossFunctions.deriv2.(l, t, y) == ref
-        @test LossFunctions.deriv2.(l, y - t) == ref
-        @test l''.(t, y) == ref
-        @test l''.(y - t) == ref
-    end
+    ref = [LossFunctions.deriv2(l,t[i],y[i]) for i in CartesianRange(size(y))]
+    yt = y .- t
+    @test @inferred(LossFunctions.deriv2(l, t, y, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv2(l, t, y)) == ref
+    @test @inferred(LossFunctions.deriv2(l, yt, AvgMode.None())) == ref
+    @test @inferred(LossFunctions.deriv2(l, yt)) == ref
+    @test LossFunctions.deriv2.(l, t, y) == ref
+    @test LossFunctions.deriv2.(l, yt) == ref
+    @test @inferred(l''(t, y, AvgMode.None())) == ref
+    @test @inferred(l''(t, y)) == ref
+    @test @inferred(l''(yt, AvgMode.None())) == ref
+    @test @inferred(l''(yt)) == ref
+    @test l''.(t, y) == ref
+    @test l''.(yt) == ref
 end
 
 @testset "Vectorized API" begin
-    targets = rand([-1,1], 10)
-    outputs = (rand(10)-.5) * 20
-
-    for loss in margin_losses
-        test_vector_value(loss, targets, outputs)
-        test_vector_deriv(loss, targets, outputs)
-        test_vector_deriv2(loss, targets, outputs)
-    end
-
-    targets = (rand(10)-.5) * 20
-    outputs = (rand(10)-.5) * 20
-    for loss in distance_losses
-        test_vector_value(loss, targets, outputs)
-        test_vector_deriv(loss, targets, outputs)
-        test_vector_deriv2(loss, targets, outputs)
+    for T in (Float32, Float64)
+        for O in (Float32, Float64)
+            @testset "Margin-based" begin
+                for (targets,outputs) in (
+                        (rand(T[-1,1],4),(rand(O,4)-O(.5)) .* O(20)),
+                        (rand(T[-1,1],4,5),(rand(O,4,5)-O(.5)) .* O(20)),
+                    )
+                    for loss in margin_losses
+                        @testset "$(loss): " begin
+                            test_vector_value(loss, targets, outputs)
+                            test_vector_deriv(loss, targets, outputs)
+                            test_vector_deriv2(loss, targets, outputs)
+                        end
+                    end
+                end
+            end
+            @testset "Distance-based" begin
+                for (targets,outputs) in (
+                        ((rand(T,4)-T(.5)) .* T(20),(rand(O,4)-O(.5)) .* O(20)),
+                        ((rand(T,4,5)-T(.5)) .* T(20),(rand(O,4,5)-O(.5)) .* O(20)),
+                    )
+                    for loss in distance_losses
+                        @testset "$(loss): " begin
+                            test_vector_value(loss, targets, outputs)
+                            test_vector_deriv(loss, targets, outputs)
+                            test_vector_deriv2(loss, targets, outputs)
+                        end
+                    end
+                end
+            end
+        end
     end
 end
 
 @testset "Broadcasting higher-order arrays" begin
-    for f in (LossFunctions.value,deriv,sumvalue,sumderiv,meanvalue,meanderiv)
+    for f in (LossFunctions.value,deriv,deriv2)
         @testset "$f" begin
 
             m,n,k = 100,99,98
@@ -91,10 +295,16 @@ end
             out1 = randn(m,n)
             out2 = randn(m,n,k)
 
-            @test isapprox(f(loss,targ1,out1), f(loss,targ2,out1))
-            @test isapprox(f(loss,targ1,out2), f(loss,targ2,out2))
-            @test isapprox(f(loss,targ1,out2), f(loss,targ3,out2))
-            @test isapprox(f(loss,targ2,out2), f(loss,targ3,out2))
+            for avg in (AvgMode.None(),AvgMode.Mean(),AvgMode.Sum())
+                @test f(loss,targ1,out1,avg) ≈ f(loss,targ2,out1,avg)
+                @test f(loss,targ1,out2,avg) ≈ f(loss,targ2,out2,avg)
+                @test f(loss,targ1,out2,avg) ≈ f(loss,targ3,out2,avg)
+                @test f(loss,targ2,out2,avg) ≈ f(loss,targ3,out2,avg)
+                @test f(loss,out1,targ1,avg) ≈ f(loss,out1,targ2,avg)
+                @test f(loss,out2,targ1,avg) ≈ f(loss,out2,targ2,avg)
+                @test f(loss,out2,targ1,avg) ≈ f(loss,out2,targ3,avg)
+                @test f(loss,out2,targ2,avg) ≈ f(loss,out2,targ3,avg)
+            end
         end
     end
 end

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -254,7 +254,8 @@ end
                         (rand(T[-1,1],4),(rand(O,4)-O(.5)) .* O(20)),
                         (rand(T[-1,1],4,5),(rand(O,4,5)-O(.5)) .* O(20)),
                     )
-                    for loss in margin_losses
+                    for loss in (LogitMarginLoss(),ModifiedHuberLoss(),
+                                 L1HingeLoss(),SigmoidLoss())
                         @testset "$(loss): " begin
                             test_vector_value(loss, targets, outputs)
                             test_vector_deriv(loss, targets, outputs)
@@ -268,7 +269,8 @@ end
                         ((rand(T,4)-T(.5)) .* T(20),(rand(O,4)-O(.5)) .* O(20)),
                         ((rand(T,4,5)-T(.5)) .* T(20),(rand(O,4,5)-O(.5)) .* O(20)),
                     )
-                    for loss in distance_losses
+                    for loss in (QuantileLoss(0.75),L2DistLoss(),
+                                 EpsilonInsLoss(1))
                         @testset "$(loss): " begin
                             test_vector_value(loss, targets, outputs)
                             test_vector_deriv(loss, targets, outputs)
@@ -277,6 +279,7 @@ end
                     end
                 end
             end
+            println("<HEARTBEAT>")
         end
     end
 end

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -341,19 +341,19 @@ end
 
 @testset "Test margin-based loss against reference function" begin
     _zerooneloss(y, t) = sign(y*t) < 0 ? 1 : 0
-    test_value(ZeroOneLoss(), _zerooneloss, [-1.,1], -10:0.1:10)
+    test_value(ZeroOneLoss(), _zerooneloss, [-1.,1], -10:0.2:10)
 
     _hingeloss(y, t) = max(0, 1 - y.*t)
-    test_value(HingeLoss(), _hingeloss, [-1.,1], -10:0.1:10)
+    test_value(HingeLoss(), _hingeloss, [-1.,1], -10:0.2:10)
 
     _l2hingeloss(y, t) = max(0, 1 - y.*t)^2
-    test_value(L2HingeLoss(), _l2hingeloss, [-1.,1], -10:0.1:10)
+    test_value(L2HingeLoss(), _l2hingeloss, [-1.,1], -10:0.2:10)
 
     _perceptronloss(y, t) = max(0, -y.*t)
-    test_value(PerceptronLoss(), _perceptronloss, [-1.,1], -10:0.1:10)
+    test_value(PerceptronLoss(), _perceptronloss, [-1.,1], -10:0.2:10)
 
     _logitmarginloss(y, t) = log(1 + exp(-y.*t))
-    test_value(LogitMarginLoss(), _logitmarginloss, [-1.,1], -10:0.1:10)
+    test_value(LogitMarginLoss(), _logitmarginloss, [-1.,1], -10:0.2:10)
 
     function _smoothedl1hingeloss(γ)
         function _value(y, t)
@@ -365,9 +365,9 @@ end
         end
         _value
     end
-    test_value(SmoothedL1HingeLoss(.5), _smoothedl1hingeloss(.5), [-1.,1], -10:0.1:10)
-    test_value(SmoothedL1HingeLoss(1), _smoothedl1hingeloss(1), [-1.,1], -10:0.1:10)
-    test_value(SmoothedL1HingeLoss(2), _smoothedl1hingeloss(2), [-1.,1], -10:0.1:10)
+    test_value(SmoothedL1HingeLoss(.5), _smoothedl1hingeloss(.5), [-1.,1], -10:0.2:10)
+    test_value(SmoothedL1HingeLoss(1), _smoothedl1hingeloss(1), [-1.,1], -10:0.2:10)
+    test_value(SmoothedL1HingeLoss(2), _smoothedl1hingeloss(2), [-1.,1], -10:0.2:10)
 
     function _modhuberloss(y, t)
         if y.*t >= -1
@@ -376,16 +376,16 @@ end
             -4.*y.*t
         end
     end
-    test_value(ModifiedHuberLoss(), _modhuberloss, [-1.,1], -10:0.1:10)
+    test_value(ModifiedHuberLoss(), _modhuberloss, [-1.,1], -10:0.2:10)
 
     _l2marginloss(y, t) = (1 - y.*t)^2
-    test_value(L2MarginLoss(), _l2marginloss, [-1.,1], -10:0.1:10)
+    test_value(L2MarginLoss(), _l2marginloss, [-1.,1], -10:0.2:10)
 
     _exploss(y, t) = exp(-y.*t)
-    test_value(ExpLoss(), _exploss, [-1.,1], -10:0.1:10)
+    test_value(ExpLoss(), _exploss, [-1.,1], -10:0.2:10)
 
     _sigmoidloss(y, t) = (1-tanh(y.*t))
-    test_value(SigmoidLoss(), _sigmoidloss, [-1., 1], -10:0.1:10)
+    test_value(SigmoidLoss(), _sigmoidloss, [-1., 1], -10:0.2:10)
 
     function _dwdmarginloss(q)
         function _value(y, t)
@@ -397,9 +397,9 @@ end
         end
         _value
     end
-    test_value(DWDMarginLoss(0.5), _dwdmarginloss(0.5), [-1., 1], -10:0.1:10)
-    test_value(DWDMarginLoss(1), _dwdmarginloss(1), [-1., 1], -10:0.1:10)
-    test_value(DWDMarginLoss(2), _dwdmarginloss(2), [-1., 1], -10:0.1:10)
+    test_value(DWDMarginLoss(0.5), _dwdmarginloss(0.5), [-1., 1], -10:0.2:10)
+    test_value(DWDMarginLoss(1), _dwdmarginloss(1), [-1., 1], -10:0.2:10)
+    test_value(DWDMarginLoss(2), _dwdmarginloss(2), [-1., 1], -10:0.2:10)
 
 end
 
@@ -467,29 +467,22 @@ end
 
 # --------------------------------------------------------------
 
-margin_losses = [LogitMarginLoss(), L1HingeLoss(), L2HingeLoss(),
-                 PerceptronLoss(), SmoothedL1HingeLoss(.5),
-                 SmoothedL1HingeLoss(1), SmoothedL1HingeLoss(2),
-                 ModifiedHuberLoss(), ZeroOneLoss(), L2MarginLoss(),
-                 ExpLoss(), SigmoidLoss(),
-                 DWDMarginLoss(.5), DWDMarginLoss(1), DWDMarginLoss(2)]
-
 @testset "Test first derivatives of margin-based losses" begin
     for loss in margin_losses
-        test_deriv(loss, -10:0.1:10)
+        test_deriv(loss, -10:0.2:10)
     end
 end
 
 @testset "Test second derivatives of margin-based losses" begin
     for loss in margin_losses
-        test_deriv2(loss, -10:0.1:10)
+        test_deriv2(loss, -10:0.2:10)
     end
 end
 
 @testset "Test margin-based scaled loss" begin
     for loss in margin_losses
-        test_scaledloss(loss, [-1.,1], -10:0.1:10)
-        test_scaledloss(loss, -10:0.1:10)
+        test_scaledloss(loss, [-1.,1], -10:0.2:10)
+        test_scaledloss(loss, -10:0.2:10)
     end
 end
 
@@ -497,7 +490,7 @@ typealias BarLoss LossFunctions.WeightedBinaryLoss{SmoothedL1HingeLoss,0.2}
 
 @testset "Test margin-based weighted loss" begin
     for loss in margin_losses
-        test_weightedloss(loss, [-1.,1], -10:0.1:10)
+        test_weightedloss(loss, [-1.,1], -10:0.2:10)
     end
     l = @inferred BarLoss(1.2)
     @test l.loss == SmoothedL1HingeLoss(1.2)
@@ -509,16 +502,6 @@ typealias BarLoss LossFunctions.WeightedBinaryLoss{SmoothedL1HingeLoss,0.2}
 end
 
 # --------------------------------------------------------------
-
-distance_losses = [L2DistLoss(), LPDistLoss(2.0), L1DistLoss(),
-                   LPDistLoss(1.0), LPDistLoss(0.5),
-                   LPDistLoss(1.5), LPDistLoss(3),
-                   LogitDistLoss(),
-                   L1EpsilonInsLoss(0.5), EpsilonInsLoss(1.5),
-                   L2EpsilonInsLoss(0.5), L2EpsilonInsLoss(1.5),
-                   PeriodicLoss(1), PeriodicLoss(1.5),
-                   HuberLoss(1), HuberLoss(1.5),
-                   QuantileLoss(.2), QuantileLoss(.5), QuantileLoss(.8)]
 
 @testset "Test first derivatives of distance-based losses" begin
     for loss in distance_losses

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -106,7 +106,7 @@ end
 
 function test_deriv(l::DistanceLoss, t_vec)
     @testset "$(l): " begin
-        for y in -20:.2:20, t in t_vec
+        for y in -10:.2:10, t in t_vec
             if isdifferentiable(l, t-y)
                 d_dual = epsilon(LossFunctions.value(l, dual(t-y, 1)))
                 d_comp = @inferred deriv(l, y, t)
@@ -142,7 +142,7 @@ end
 
 function test_deriv(l::SupervisedLoss, t_vec)
     @testset "$(l): " begin
-        for y in -20:.2:20, t in t_vec
+        for y in -10:.2:10, t in t_vec
             if isdifferentiable(l, y, t)
                 d_dual = epsilon(LossFunctions.value(l, y, dual(t, 1)))
                 d_comp = @inferred deriv(l, y, t)
@@ -191,7 +191,7 @@ end
 
 function test_deriv2(l::DistanceLoss, t_vec)
     @testset "$(l): " begin
-        for y in -20:.2:20, t in t_vec
+        for y in -10:.2:10, t in t_vec
             if istwicedifferentiable(l, t-y) && isdifferentiable(l, t-y)
                 d2_dual = epsilon(deriv(l, dual(t-y, 1)))
                 d2_comp = @inferred deriv2(l, y, t)
@@ -505,7 +505,7 @@ end
 
 @testset "Test first derivatives of distance-based losses" begin
     for loss in distance_losses
-        test_deriv(loss, -20:0.5:20)
+        test_deriv(loss, -10:0.5:10)
     end
 end
 
@@ -515,7 +515,7 @@ end
 
 @testset "Test second derivatives of distance-based losses" begin
     for loss in distance_losses
-        test_deriv2(loss, -20:0.5:20)
+        test_deriv2(loss, -10:0.5:10)
     end
 end
 
@@ -523,8 +523,8 @@ typealias FooLoss LossFunctions.ScaledDistanceLoss{L2EpsilonInsLoss,2}
 
 @testset "Test distance-based scaled loss" begin
     for loss in distance_losses
-        test_scaledloss(loss, -20:.2:20, -20:0.5:20)
-        test_scaledloss(loss, -20:0.5:20)
+        test_scaledloss(loss, -10:.2:10, -10:0.5:10)
+        test_scaledloss(loss, -10:0.5:10)
     end
 
     l = @inferred FooLoss(1.2)

--- a/test/tst_properties.jl
+++ b/test/tst_properties.jl
@@ -566,7 +566,6 @@ end
     @test isunivfishercons(loss) == true
 end
 
-
 @testset "ExpLoss" begin
     loss = ExpLoss()
 
@@ -595,7 +594,6 @@ end
     @test isunivfishercons(loss) == true
 end
 
-
 @testset "SigmoidLoss" begin
     loss = SigmoidLoss()
 
@@ -623,7 +621,6 @@ end
     @test isfishercons(loss) == true
     @test isunivfishercons(loss) == true
 end
-
 
 @testset "DWDMarginLoss" begin
     loss = DWDMarginLoss(2)
@@ -654,6 +651,7 @@ end
 end
 
 # --------------------------------------------------------------
+
 function compare_losses(l1, l2, ccal = true)
     @test isminimizable(l1) == isminimizable(l2)
 
@@ -682,15 +680,8 @@ end
 compare_losses(PoissonLoss(), 2*PoissonLoss())
 compare_losses(PoissonLoss(), 0.5*PoissonLoss())
 
-margins = [LogitMarginLoss(), L1HingeLoss(), L2HingeLoss(),
-           PerceptronLoss(), SmoothedL1HingeLoss(.5),
-           SmoothedL1HingeLoss(1), SmoothedL1HingeLoss(2),
-           ModifiedHuberLoss(), ZeroOneLoss(),
-           L2MarginLoss(), ExpLoss(), SigmoidLoss(),
-           DWDMarginLoss(0.5), DWDMarginLoss(1), DWDMarginLoss(2)]
-
 @testset "Weighted Margin-based" begin
-    for loss in margins
+    for loss in margin_losses
         @testset "$loss" begin
             compare_losses(loss, weightedloss(loss,0.2), false)
             compare_losses(loss, weightedloss(loss,0.5), true)
@@ -700,7 +691,7 @@ margins = [LogitMarginLoss(), L1HingeLoss(), L2HingeLoss(),
 end
 
 @testset "Scaled Margin-based" begin
-    for loss in margins
+    for loss in margin_losses
         @testset "$loss" begin
             compare_losses(loss, 2*loss)
             compare_losses(loss, 0.5*loss)
@@ -709,16 +700,11 @@ end
 end
 
 @testset "Scaled Distance-based" begin
-    distance = [L2DistLoss(), LPDistLoss(2.0), L1DistLoss(),
-                LPDistLoss(1.0), LPDistLoss(0.5), LPDistLoss(1.5),
-                LPDistLoss(3), LogitDistLoss(), L1EpsilonInsLoss(0.5),
-                EpsilonInsLoss(1.5), L2EpsilonInsLoss(0.5),
-                L2EpsilonInsLoss(1.5), PeriodicLoss(1),
-                HuberLoss(1), HuberLoss(1.5)]
-    for loss in distance
+    for loss in distance_losses
         @testset "$loss" begin
             compare_losses(loss, 2*loss)
             compare_losses(loss, 0.5*loss)
         end
     end
 end
+


### PR DESCRIPTION
I am combining the initial broadcast @ahwillia implemented with the concept of an `AverageMode`, which I originally planned for MLMetrics. Introducing it here instead will allow for some synergy and a more consistent interface, as MLMetrics will depends on LossFunctions.
Basically I am planning on deprecating `meanvalue` and `sumvalue` in favour of specifying an additional parameter.

```julia
julia> value(L2DistLoss(), [4,6,9], [1,2,3]) # this just calls "value.(...)"
3-element Array{Int64,1}:
  9
 16
 36

julia> value(L2DistLoss(), [4,6,9], [1,2,3], AvgMode.Sum())
61

julia> value(L2DistLoss(), [4,6,9], [1,2,3], AvgMode.Micro())
20.333333333333332
```

For these losses `AvgMode.Micro` and `AvgMode.Macro` yield the same result. The distinction between a micro- and a macro average will be more interesting in MLMetrics.

The real power comes with matrices or higher dimensional arrays, because this change will allow for multivariate regression problems. Basically I allow the user to choose if he/she would like to sum/average over all observations or just over individual observations. The concept of `ObsDim` allows choosing which dimension of the array denotes the observations and is also used in MLDataUtils and MLLabelUtils.

```julia
julia> value(L2DistLoss(), rand(2,5), rand(2,5))
2×5 Array{Float64,2}:
 0.578745     0.144435    0.0634566    0.0871816  0.293819
 0.000124382  1.05113e-5  0.000301812  0.0732131  0.052562

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Sum())
1.8460235498014388

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Sum(), ObsDim.First()) # each row is an obs
2-element Array{Float64,1}:
 0.608044
 1.09483 

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Sum(), ObsDim.Last()) # each col is an obs
5-element Array{Float64,1}:
 0.41182 
 0.669381
 0.123093
 0.016917
 0.10979 

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Micro()) # total unweighted average
0.2747918979060879

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Micro(), ObsDim.First()) # average per row
2-element Array{Float64,1}:
 0.148631
 0.146248

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Micro(), ObsDim.Last()) # average per column
5-element Array{Float64,1}:
 0.112903  
 0.0305063 
 0.00763535
 0.0959092 
 0.276229  

julia> value(L2DistLoss(), rand(2,5), rand(2,5), AvgMode.Weighted([1,2]), ObsDim.First()) # weighted average observations
5.006367100102387e12 # this value is fishy, may have a bug here 
```

I have not implemented any tests yet, but I thought this would be a good time to allow for opinions and criticism