### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 StatsBase 0.8.0
 LearnBase 0.1.3 0.2.0
 RecipesBase


### PR DESCRIPTION
since `struct` syntax wouldn't work in early 0.6.0-dev versions of julia,
better to stick with 0.5-compatible versions of the package there