### PR TITLE
Ordinals and minor changes to LogitDistLoss

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -62,6 +62,7 @@ include("supervised/margin.jl")
 include("supervised/scaledloss.jl")
 include("supervised/weightedbinary.jl")
 include("supervised/other.jl")
+include("supervised/ordinal.jl")
 include("supervised/io.jl")
 
 # allow using some special losses as function

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -46,6 +46,8 @@ export
     CrossentropyLoss,
     ZeroOneLoss,
 
+    OrdinalMarginLoss,
+
     weightedloss,
 
     AvgMode

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -408,11 +408,7 @@ It is strictly convex and Lipschitz continuous.
 struct LogitDistLoss <: DistanceLoss end
 
 function value(loss::LogitDistLoss, difference::Number)
-    #=
     er = exp(difference)
-    T = typeof(er)
-    -log(T(4) * er / abs2(one(T) + er))
-    =#
     T = typeof(er)
     -log(T(4)) - difference + 2log(one(T) + er)
 end

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -408,9 +408,13 @@ It is strictly convex and Lipschitz continuous.
 struct LogitDistLoss <: DistanceLoss end
 
 function value(loss::LogitDistLoss, difference::Number)
+    #=
     er = exp(difference)
     T = typeof(er)
     -log(T(4) * er / abs2(one(T) + er))
+    =#
+    T = typeof(er)
+    -log(T(4)) - difference + 2log(one(T) + er)
 end
 function deriv{T<:Number}(loss::LogitDistLoss, difference::T)
     tanh(difference / T(2))
@@ -424,7 +428,7 @@ function value_deriv(loss::LogitDistLoss, difference::Number)
     er = exp(difference)
     T = typeof(er)
     er1 = one(T) + er
-    -log(T(4) * er / abs2(er1)), (er - one(T)) / (er1)
+    -log(T(4)) - difference + 2log(er1), (er - one(T)) / (er1)
 end
 
 issymmetric(::LogitDistLoss) = true

--- a/src/supervised/ordinal.jl
+++ b/src/supervised/ordinal.jl
@@ -37,8 +37,10 @@ end =#
 for fun in (:value, :deriv, :deriv2)
     @eval @fastmath function ($fun)(loss::OrdinalMarginLoss{T, N},
                     target::Number, output::Number) where {T <: MarginLoss, N}
-        retval = zero(output)
-        for t = 1:N
+        not_target = 1 != target
+        sgn = sign(target - 1)
+        retval = not_target * ($fun)(loss.loss, sgn, output - 1)
+        for t = 2:N
             not_target = (t != target)
             sgn = sign(target - t)
             retval += not_target * ($fun)(loss.loss, sgn, output - t)

--- a/src/supervised/ordinal.jl
+++ b/src/supervised/ordinal.jl
@@ -1,0 +1,28 @@
+struct OrdinalMarginLoss <: SupervisedLoss
+    loss::MarginLoss
+    nlevels::Int
+end
+
+for fun in (:value, :deriv, :deriv2)
+    @eval @fastmath function ($fun)(loss::OrdinalMarginLoss, target::Number, output::Number)
+        retval = 0
+        for t = 1:target - 1
+            retval += ($fun)(loss.loss, 1, output - t - 1)
+        end
+        for t = target + 1:loss.nlevels
+            retval += ($fun)(loss.loss, -1, output - t + 1)
+        end
+        retval
+    end
+end
+
+for prop in [:isminimizable, :isdifferentiable,
+             :istwicedifferentiable,
+             :isconvex, :isstrictlyconvex,
+             :isstronglyconvex, :isnemitski,
+             :isunivfishercons, :isfishercons,
+             :islipschitzcont, :islocallylipschitzcont,
+             :isclipable, :ismarginbased,
+             :isdistancebased]
+    @eval ($prop)(l::OrdinalMarginLoss) = ($prop)(l.loss)
+end

--- a/src/supervised/ordinal.jl
+++ b/src/supervised/ordinal.jl
@@ -2,26 +2,46 @@
     OrdinalMarginLoss <: SupervisedLoss
 
 Modifies a margin loss `loss` to be used on an ordinal domain with
-number of levels `nlevels`. It treats each level as an integer between
-1 and `nlevels`, inclusive, and penalizes output according to the sum of
+number of levels `N`. It treats each level as an integer between
+1 and `N`, inclusive, and penalizes output according to the sum of
 level thresholds crossed relative to target
 
 Assumes target is encoded in an Index encoding scheme where levels are
-numbered between 1 and `nlevels`
+numbered between 1 and `N`
 """
-struct OrdinalMarginLoss <: SupervisedLoss
-    loss::MarginLoss
-    nlevels::Int
+struct OrdinalMarginLoss{L<:MarginLoss, N} <: SupervisedLoss
+    loss::L
 end
 
+function OrdinalMarginLoss(loss::T, ::Type{Val{N}}) where {T<:MarginLoss,N}
+  typeof(N) <: Number || _serror()
+  OrdinalMarginLoss{T,N}(loss)
+end
+
+#=
 for fun in (:value, :deriv, :deriv2)
-    @eval @fastmath function ($fun)(loss::OrdinalMarginLoss, target::Number, output::Number)
-        retval = 0
-        for t = 1:target - 1
-            retval += ($fun)(loss.loss, 1, output - t)
+    @eval @fastmath @generated function ($fun)(loss::OrdinalMarginLoss{T, N},
+                    target::Number, output::Number) where {T <: MarginLoss, N}
+        quote
+            retval = zero(output)
+            @nexprs $N t -> begin
+                not_target = (t != target)
+                sgn = sign(target - t)
+                retval += not_target * ($($fun))(loss.loss, sgn, output - t)
+            end
+            retval
         end
-        for t = target + 1:loss.nlevels
-            retval += ($fun)(loss.loss, -1, output - t)
+    end
+end =#
+
+for fun in (:value, :deriv, :deriv2)
+    @eval @fastmath function ($fun)(loss::OrdinalMarginLoss{T, N},
+                    target::Number, output::Number) where {T <: MarginLoss, N}
+        retval = zero(output)
+        for t = 1:N
+            not_target = (t != target)
+            sgn = sign(target - t)
+            retval += not_target * ($fun)(loss.loss, sgn, output - t)
         end
         retval
     end
@@ -37,11 +57,12 @@ for prop in [:isminimizable, :isdifferentiable,
 end
 
 for fun in (:isdifferentiable, :istwicedifferentiable)
-    @eval function ($fun)(loss::OrdinalMarginLoss, target::Number, output::Number)
+    @eval function ($fun)(loss::OrdinalMarginLoss{T, N},
+                target::Number, output::Number) where {T, N}
         for t = 1:target - 1
             ($fun)(loss.loss, output - t) || return false
         end
-        for t = target + 1:loss.nlevels
+        for t = target + 1:N
             ($fun)(loss.loss, t - output) || return false
         end
         return true

--- a/src/supervised/ordinal.jl
+++ b/src/supervised/ordinal.jl
@@ -7,10 +7,10 @@ for fun in (:value, :deriv, :deriv2)
     @eval @fastmath function ($fun)(loss::OrdinalMarginLoss, target::Number, output::Number)
         retval = 0
         for t = 1:target - 1
-            retval += ($fun)(loss.loss, 1, output - t - 1)
+            retval += ($fun)(loss.loss, 1, output - t)
         end
         for t = target + 1:loss.nlevels
-            retval += ($fun)(loss.loss, -1, output - t + 1)
+            retval += ($fun)(loss.loss, -1, output - t)
         end
         retval
     end

--- a/src/supervised/ordinal.jl
+++ b/src/supervised/ordinal.jl
@@ -1,3 +1,14 @@
+"""
+    OrdinalMarginLoss <: SupervisedLoss
+
+Modifies a margin loss `loss` to be used on an ordinal domain with
+number of levels `nlevels`. It treats each level as an integer between
+1 and `nlevels`, inclusive, and penalizes output according to the sum of
+level thresholds crossed relative to target
+
+Assumes target is encoded in an Index encoding scheme where levels are
+numbered between 1 and `nlevels`
+"""
 struct OrdinalMarginLoss <: SupervisedLoss
     loss::MarginLoss
     nlevels::Int
@@ -21,8 +32,18 @@ for prop in [:isminimizable, :isdifferentiable,
              :isconvex, :isstrictlyconvex,
              :isstronglyconvex, :isnemitski,
              :isunivfishercons, :isfishercons,
-             :islipschitzcont, :islocallylipschitzcont,
-             :isclipable, :ismarginbased,
-             :isdistancebased]
+             :islipschitzcont, :islocallylipschitzcont]
     @eval ($prop)(l::OrdinalMarginLoss) = ($prop)(l.loss)
+end
+
+for fun in (:isdifferentiable, :istwicedifferentiable)
+    @eval function ($fun)(loss::OrdinalMarginLoss, target::Number, output::Number)
+        for t = 1:target - 1
+            ($fun)(loss.loss, output - t) || return false
+        end
+        for t = target + 1:loss.nlevels
+            ($fun)(loss.loss, t - output) || return false
+        end
+        return true
+    end
 end

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -316,4 +316,3 @@ end
         end
     end
 end
-

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -476,6 +476,22 @@ end
     test_value(QuantileLoss(.7), _quantileloss, yr, tr)
 end
 
+@testset "Test ordinal losses against reference function" begin
+    function _ordinalhingeloss(y, t)
+        val = 0
+        for yp = 1:y - 1
+            val += max(0, 1 - t + yp)
+        end
+        for yp = y + 1:5
+            val += max(0, 1 + t - yp)
+        end
+        val
+    end
+    y = rand(1:5, 10); t = randn(10) .+ 3
+    test_value(OrdinalMarginLoss(HingeLoss(), 5), _ordinalhingeloss, y, t)
+end
+
+
 @testset "Test other loss against reference function" begin
     _crossentropyloss(y, t) = -y*log(t) - (1-y)*log(1-t)
     test_value(CrossentropyLoss(), _crossentropyloss, 0:0.01:1, 0.01:0.01:0.99)
@@ -598,4 +614,3 @@ end
         end
     end
 end
-

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -488,7 +488,7 @@ end
         val
     end
     y = rand(1:5, 10); t = randn(10) .+ 3
-    test_value(OrdinalMarginLoss(HingeLoss(), 5), _ordinalhingeloss, y, t)
+    test_value(OrdinalMarginLoss(HingeLoss(), Val{5}), _ordinalhingeloss, y, t)
 end
 
 


### PR DESCRIPTION
LogitDistLoss incurs numerical problems for large values of diff, since there is exp(abs2(...)) which blows up to Inf very quickly. These problems are improved somewhat by simplifying the equation.

I also added an 'ordinalization' of margin losses that allows them to predict over ordinal targets, so that an output greater than the maximum or less than the minimum is not penalized strongly as in a DiffLoss