### PR TITLE
streamline OrdinalMarginLoss construction

### DIFF
--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -47,6 +47,7 @@ export
     ZeroOneLoss,
 
     OrdinalMarginLoss,
+    OrdinalHingeLoss,
 
     weightedloss,
 

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -318,6 +318,7 @@ end
     @test L2DistLoss === LPDistLoss{2}
     @test HingeLoss === L1HingeLoss
     @test EpsilonInsLoss === L1EpsilonInsLoss
+    @test OrdinalHingeLoss === OrdinalMarginLoss{HingeLoss}
 end
 
 @testset "Test typestable supervised loss for type stability" begin
@@ -476,6 +477,9 @@ end
     test_value(QuantileLoss(.7), _quantileloss, yr, tr)
 end
 
+const OrdinalSmoothedHingeLoss = OrdinalMarginLoss{<:SmoothedL1HingeLoss}
+@test OrdinalSmoothedHingeLoss(4, 2.1) === OrdinalMarginLoss(SmoothedL1HingeLoss(2.1), 4)
+
 @testset "Test ordinal losses against reference function" begin
     function _ordinalhingeloss(y, t)
         val = 0
@@ -488,7 +492,8 @@ end
         val
     end
     y = rand(1:5, 10); t = randn(10) .+ 3
-    test_value(OrdinalMarginLoss(HingeLoss(), Val{5}), _ordinalhingeloss, y, t)
+    @test OrdinalHingeLoss(5) === OrdinalMarginLoss(HingeLoss(), 5)
+    test_value(OrdinalMarginLoss(HingeLoss(), 5), _ordinalhingeloss, y, t)
 end
 
 


### PR DESCRIPTION
Since we ended up not doing the unrolling, it seems more flexible to not make `N` a type var. This way its cleaner for `N` to depend on the data.

Aside from this, I wrote the constructor of `OrdinalMarginLoss` such that its easy to define clean typealiases.

For example the following is possible:

```julia
const OrdinalHingeLoss = OrdinalMarginLoss{HingeLoss}
OrdinalHingeLoss(5) # N=5
```

Since `HingeLoss` has no free parameters the above is quite simple, but the construction even works for all `MarginLoss` that do have free paramaters, such as the `SmoothedL1HingeLoss`

```julia
julia> const OrdinalSmoothedHingeLoss = OrdinalMarginLoss{<:SmoothedL1HingeLoss};

julia> OrdinalSmoothedHingeLoss(5, 2.1)
OrdinalMarginLoss{SmoothedL1HingeLoss{Float64}}(SmoothedL1HingeLoss{Float64}(2.1), 4)
```

cc: @mihirparadkar 