### PR TITLE
Use numerically stable functions from statsfuns

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6.0-pre
 StatsBase 0.15.0
+StatsFuns 0.5.0
 LearnBase 0.1.3 0.2.0
 RecipesBase

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -3,6 +3,8 @@ module LossFunctions
 
 using RecipesBase
 
+using StatsFuns
+
 import Base.*
 using Base.Cartesian
 

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -408,9 +408,9 @@ It is strictly convex and Lipschitz continuous.
 struct LogitDistLoss <: DistanceLoss end
 
 function value(loss::LogitDistLoss, difference::Number)
-    er = exp(difference)
-    T = typeof(er)
-    -log(T(4)) - difference + 2log(one(T) + er)
+    spd = softplus(difference)
+    T = typeof(spd)
+    -log(T(4)) - difference + 2spd
 end
 function deriv{T<:Number}(loss::LogitDistLoss, difference::T)
     tanh(difference / T(2))
@@ -423,8 +423,9 @@ end
 function value_deriv(loss::LogitDistLoss, difference::Number)
     er = exp(difference)
     T = typeof(er)
+    spd = softplus(difference)
     er1 = one(T) + er
-    -log(T(4)) - difference + 2log(er1), (er - one(T)) / (er1)
+    -log(T(4)) - difference + 2spd, (er - one(T)) / (er1)
 end
 
 issymmetric(::LogitDistLoss) = true

--- a/src/supervised/margin.jl
+++ b/src/supervised/margin.jl
@@ -127,8 +127,8 @@ times differentiable, strictly convex, and Lipschitz continuous.
 ```
 """
 struct LogitMarginLoss <: MarginLoss end
-value(loss::LogitMarginLoss, agreement::Number) = log1p(exp(-agreement))
-deriv(loss::LogitMarginLoss, agreement::Number) = -one(agreement) / (one(agreement) + exp(agreement))
+value(loss::LogitMarginLoss, agreement::Number) = softplus(-agreement)
+deriv(loss::LogitMarginLoss, agreement::Number) = -logistic(-agreement)
 deriv2(loss::LogitMarginLoss, agreement::Number) = (eᵗ = exp(agreement); eᵗ / abs2(one(eᵗ) + eᵗ))
 value_deriv(loss::LogitMarginLoss, agreement::Number) = (eᵗ = exp(-agreement); (log1p(eᵗ), -eᵗ / (one(eᵗ) + eᵗ)))
 


### PR DESCRIPTION
I'm opening this PR for discussion purposes. StatsFuns has quite a few useful functions for probabilistic loss functions (cross-entropy, logistic margin, logitdistance, etc.), and they emphasize numerical stability (currently, `value(LogitDistLoss(), 1000)` gives `Inf` when it should give `1000`, but it exhibits proper behavior when using softplus.