### PR TITLE
Remove space between docstring and thing

### DIFF
--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -33,7 +33,6 @@ Cross-entropy loss also known as log loss and logistic loss is defined as:
 
 ``L(target, output) = - target*ln(output) - (1-target)*ln(1-output)``
 """
-
 struct CrossentropyLoss <: SupervisedLoss end
 const LogitProbLoss = CrossentropyLoss
 


### PR DESCRIPTION
This was causing an error in OnlineStats (I think) when building a sysimg with PackageCompiler.

If not too much trouble, a version tag including this would be great: https://www.youtube.com/watch?v=JFRa7Ovym8s