### PR TITLE
removes restriction on result to be an abstract array

### DIFF
--- a/src/supervised/supervised.jl
+++ b/src/supervised/supervised.jl
@@ -260,7 +260,7 @@ for (FUN, DESC, EXAMPLE) in (
             quote
                 $(Expr(:meta, :inline))
                 S = typeof(($($FUN))(loss, one(Q), one(T)))
-                ($($FUN)).(Ref(loss), target, output)::Array{S,$(max(N,M))}
+                ($($FUN)).(Ref(loss), target, output)
             end
         end
 


### PR DESCRIPTION
I wanted to use LossFunctions with Flux Tracked Arrays so I needed to remove the restriction on the return type.