### PR TITLE
[WIP] Generalize ZeroOneLoss for multiple classes

### DIFF
--- a/docs/src/losses/margin.md
+++ b/docs/src/losses/margin.md
@@ -18,18 +18,6 @@ they agree with the sign of the target.
 This section lists all the subtypes of [`MarginLoss`](@ref)
 that are implemented in this package.
 
-## ZeroOneLoss
-
-```@docs
-ZeroOneLoss
-```
-
-Lossfunction | Derivative
--------------|------------------
-![loss](https://rawgit.com/JuliaML/FileStorage/master/LossFunctions/ZeroOneLoss1.svg) | ![deriv](https://rawgit.com/JuliaML/FileStorage/master/LossFunctions/ZeroOneLoss2.svg)
-``L(a) = \begin{cases} 1 & \quad \text{if } a < 0 \\ 0 & \quad \text{otherwise}\\ \end{cases}`` | ``L'(a) = 0``
-
-
 ## PerceptronLoss
 
 ```@docs

--- a/src/supervised/margin.jl
+++ b/src/supervised/margin.jl
@@ -5,60 +5,6 @@
 # ============================================================
 
 @doc doc"""
-    ZeroOneLoss <: MarginLoss
-
-The classical classification loss. It penalizes every misclassified
-observation with a loss of `1` while every correctly classified
-observation has a loss of `0`.
-It is not convex nor continuous and thus seldom used directly.
-Instead one usually works with some classification-calibrated
-surrogate loss, such as [L1HingeLoss](@ref).
-
-```math
-L(a) = \begin{cases} 1 & \quad \text{if } a < 0 \\ 0 & \quad \text{if } a >= 0\\ \end{cases}
-```
-
----
-```
-              Lossfunction                     Derivative
-      ┌────────────┬────────────┐      ┌────────────┬────────────┐
-    1 │------------┐            │    1 │                         │
-      │            |            │      │                         │
-      │            |            │      │                         │
-      │            |            │      │_________________________│
-      │            |            │      │                         │
-      │            |            │      │                         │
-      │            |            │      │                         │
-    0 │            └------------│   -1 │                         │
-      └────────────┴────────────┘      └────────────┴────────────┘
-      -2                        2      -2                        2
-                y * h(x)                         y * h(x)
-```
-"""
-struct ZeroOneLoss <: MarginLoss end
-
-deriv(loss::ZeroOneLoss, target::Number, output::Number) = zero(output)
-deriv2(loss::ZeroOneLoss, target::Number, output::Number) = zero(output)
-
-value(loss::ZeroOneLoss, agreement::T) where {T<:Number} = sign(agreement) < 0 ? one(T) : zero(T)
-deriv(loss::ZeroOneLoss, agreement::T) where {T<:Number} = zero(T)
-deriv2(loss::ZeroOneLoss, agreement::T) where {T<:Number} = zero(T)
-value_deriv(loss::ZeroOneLoss, agreement::T) where {T<:Number} = sign(agreement) < 0 ? (one(T), zero(T)) : (zero(T), zero(T))
-
-isminimizable(::ZeroOneLoss) = true
-isdifferentiable(::ZeroOneLoss) = false
-isdifferentiable(::ZeroOneLoss, at) = at != 0
-istwicedifferentiable(::ZeroOneLoss) = false
-istwicedifferentiable(::ZeroOneLoss, at) = at != 0
-isnemitski(::ZeroOneLoss) = true
-islipschitzcont(::ZeroOneLoss) = true
-isconvex(::ZeroOneLoss) = false
-isclasscalibrated(loss::ZeroOneLoss) = true
-isclipable(::ZeroOneLoss) = true
-
-# ============================================================
-
-@doc doc"""
     PerceptronLoss <: MarginLoss
 
 The perceptron loss linearly penalizes every prediction where the

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -1,4 +1,40 @@
 @doc doc"""
+    ZeroOneLoss <: SupervisedLoss
+
+The classical classification loss. It penalizes every misclassified
+observation with a loss of `1` while every correctly classified
+observation has a loss of `0`.
+It is not convex nor continuous and thus seldom used directly.
+Instead one usually works with some classification-calibrated
+surrogate loss, such as [L1HingeLoss](@ref).
+"""
+struct ZeroOneLoss <: SupervisedLoss end
+
+agreement(target, output) = target == output
+
+value(loss::ZeroOneLoss, agreement::Bool) = agreement ? 0 : 1
+deriv(loss::ZeroOneLoss, agreement::Bool) = 0
+deriv2(loss::ZeroOneLoss, agreement::Bool) = 0
+value_deriv(loss::ZeroOneLoss, agreement::Bool) = agreement ? (0, 0) : (1, 0)
+
+value(loss::ZeroOneLoss, target::Number, output::Number) = value(loss, agreement(target, output))
+deriv(loss::ZeroOneLoss, target::Number, output::Number) = deriv(loss, agreement(target, output))
+deriv2(loss::ZeroOneLoss, target::Number, output::Number) = deriv2(loss, agreement(target, output))
+
+isminimizable(::ZeroOneLoss) = true
+isdifferentiable(::ZeroOneLoss) = false
+isdifferentiable(::ZeroOneLoss, at) = at != 0
+istwicedifferentiable(::ZeroOneLoss) = false
+istwicedifferentiable(::ZeroOneLoss, at) = at != 0
+isnemitski(::ZeroOneLoss) = true
+islipschitzcont(::ZeroOneLoss) = true
+isconvex(::ZeroOneLoss) = false
+isclasscalibrated(::ZeroOneLoss) = true
+isclipable(::ZeroOneLoss) = true
+
+# ============================================================
+
+@doc doc"""
     PoissonLoss <: SupervisedLoss
 
 Loss under a Poisson noise distribution (KL-divergence)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,9 +30,13 @@ margin_losses = [
     LogitMarginLoss(), L1HingeLoss(), L2HingeLoss(),
     PerceptronLoss(), SmoothedL1HingeLoss(.5),
     SmoothedL1HingeLoss(1), SmoothedL1HingeLoss(2),
-    ModifiedHuberLoss(), ZeroOneLoss(), L2MarginLoss(),
+    ModifiedHuberLoss(), L2MarginLoss(),
     ExpLoss(), SigmoidLoss(), DWDMarginLoss(.5),
     DWDMarginLoss(1), DWDMarginLoss(2)
+]
+
+other_losses = [
+    ZeroOneLoss(), CrossentropyLoss(), PoissonLoss()
 ]
 
 for t in tests

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -346,9 +346,6 @@ end
 println("<HEARTBEAT>")
 
 @testset "Test margin-based loss against reference function" begin
-    _zerooneloss(y, t) = sign(y*t) < 0 ? 1 : 0
-    test_value(ZeroOneLoss(), _zerooneloss, [-1.,1], -10:0.2:10)
-
     _hingeloss(y, t) = max(0, 1 - y.*t)
     test_value(HingeLoss(), _hingeloss, [-1.,1], -10:0.2:10)
 
@@ -482,7 +479,10 @@ const OrdinalSmoothedHingeLoss = OrdinalMarginLoss{<:SmoothedL1HingeLoss}
 end
 
 
-@testset "Test other loss against reference function" begin
+@testset "Test other losses against reference function" begin
+    _zerooneloss(y, t) = y == t ? 0 : 1
+    test_value(ZeroOneLoss(), _zerooneloss, [-1.,1], -10:0.2:10)
+
     _crossentropyloss(y, t) = -y*log(t) - (1-y)*log(1-t)
     test_value(CrossentropyLoss(), _crossentropyloss, 0:0.01:1, 0.01:0.01:0.99)
 

--- a/test/tst_properties.jl
+++ b/test/tst_properties.jl
@@ -366,7 +366,7 @@ end
     @test islipschitzcont(loss) == true
     @test islocallylipschitzcont(loss) == true
     @test isclipable(loss) == true
-    @test ismarginbased(loss) == true
+    @test ismarginbased(loss) == false
     @test isdistancebased(loss) == false
     @test issymmetric(loss) == false
     @test isclasscalibrated(loss) == true
@@ -707,4 +707,3 @@ end
         end
     end
 end
-


### PR DESCRIPTION
This is an attempt to generalise the `ZeroOneLoss` to multi-class problems. As described in the existing doc string, the loss is more general than just checking the sign of the product of `y` and `yhat`. It is more general in the sense that we check an "agreement" between `y` and `yhat` and return either `0` or `1`, i.e. the misclassification indicator function.

Overall, the conceptual changes in this PR consist of:

1. `ZeroOneLoss` is now a subtype of `SupervisedLoss` as opposed to the more restrictive `MarginLoss` type
2. It works for a pair of `Number` as before, and I will continue this PR to make it work with pair of `CategoricalValue` from `CategoricalArrays.jl`

Could you please provide feedback in this breaking change? Do you agree that we could move this very specific (seldom used as the doc string says) loss to the "other" family of losses along with `CrossentropyLoss` and `PoissonLoss`? In the future these "other" losses could be classified into more specific subtype of SupervisedLoss. For example, `ZeroOneLoss` has a function `psi(y, yhat)` that is simply `psi(y, yhat) = y == yhat` unlike the function `psi(y, yhat) = y*yhat` for margin-based losses, and unlike the function `psi(y, yhat) = y - yhat` for distance-based losses.

I appreciate if you can take a look at this PR, and provide feedback quickly. We are writing a paper that depends on this, and it would be nice to use a stable version of LossFunctions.jl in the Manifest.toml for the accompanying scripts.