### PR TITLE
Update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _build/
 _static/
 _templates
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,32 +3,26 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.1
+  - 1.2
+  - 1.3
   - nightly
-notifications:
-  email: false
-git:
-  depth: 99999999
-
-matrix:
+jobs:
   allow_failures:
     - julia: nightly
-
-jobs:
+  fast_finish: true
   include:
-    - stage: deploy
-      julia: 0.7
+    - stage: "Documentation"
+      julia: 1.3
       os: linux
       script:
-        - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("LossFunctions")'
-        - julia -e 'import Pkg; ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps); Pkg.add("LearnBase")'
-        - julia -e 'import LossFunctions; ENV["DOCUMENTER_DEBUG"] = "true"; include(joinpath("docs","make.jl"))'
-
-## uncomment the following lines to override the default test script
-#script:
-#    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#    - julia --check-bounds=yes --color=yes -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("LossFunctions"); Pkg.test("LossFunctions"; coverage=true)';
-
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+        - julia --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(path=pwd()))'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
+notifications:
+  email: false
 after_success:
-- julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage")'
+  - julia -e 'using Coverage; Codecov.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LossFunctions"
-uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
-version = "0.2.1"
+uuid = "6e9bb92d-87bd-4e8a-b639-80472d1675c6"
+version = "0.5.2"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -10,11 +10,17 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[compat]
+LearnBase = "0.3"
+RecipesBase = "0.8"
+StatsBase = "0.33"
+julia = "1"
+
 [extras]
-DualNumbers = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DualNumbers", "Test", "Statistics", "Random"]
+test = ["DualNumbers", "Random", "Statistics", "Test"]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ that are commonly used in Machine Learning._
 :-------------------------------:|:----------------------------------:
 ![distance_losses](https://rawgithub.com/JuliaML/FileStorage/master/LossFunctions/distance.svg) | ![margin_losses](https://rawgithub.com/JuliaML/FileStorage/master/LossFunctions/margin.svg)
 
-Others: `PeriodicLoss`, `PoissonLoss`, `ScaledLoss`,
-`WeightedBinaryLoss`
+Please consult the documentation for other losses available.
 
 ## Introduction
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.7.0
-StatsBase 0.24.0
-LearnBase 0.2.0 0.3.0
-RecipesBase

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -64,10 +64,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[LossFunctions]]
-deps = ["InteractiveUtils", "LearnBase", "Markdown", "Random", "RecipesBase", "SparseArrays", "Statistics", "StatsBase", "Test"]
-git-tree-sha1 = "08d87fec43e7d335811dfae5b55dbfc5690e915b"
-uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
-version = "0.5.1"
+deps = ["InteractiveUtils", "LearnBase", "Markdown", "RecipesBase", "SparseArrays", "StatsBase"]
+path = ".."
+uuid = "6e9bb92d-87bd-4e8a-b639-80472d1675c6"
+version = "0.5.2"
 
 [[Markdown]]
 deps = ["Base64"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,0 +1,156 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[DataAPI]]
+git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.1.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "73eb18320fe3ba58790c8b8f6f89420f0a622773"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.17.11"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.1"
+
+[[Documenter]]
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "d45c163c7a3ae293c15361acc52882c0f853f97c"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.23.4"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "b34d7cef7b337321e97d22242c3c2b91f476748e"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.0"
+
+[[LearnBase]]
+deps = ["LinearAlgebra", "StatsBase"]
+git-tree-sha1 = "47e6f4623c1db88570c7a7fa66c6528b92ba4725"
+uuid = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
+version = "0.3.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[LossFunctions]]
+deps = ["InteractiveUtils", "LearnBase", "Markdown", "Random", "RecipesBase", "SparseArrays", "Statistics", "StatsBase", "Test"]
+git-tree-sha1 = "08d87fec43e7d335811dfae5b55dbfc5690e915b"
+uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
+version = "0.5.1"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "de0a5ce9e5289f27df672ffabef4d1e5861247d5"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.4.3"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.1.0"
+
+[[Parsers]]
+deps = ["Dates", "Test"]
+git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.1"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[RecipesBase]]
+git-tree-sha1 = "b4ed4a7f988ea2340017916f7c9e5d7560b52cae"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "0.8.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.1"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
+git-tree-sha1 = "a6102b1f364befdb05746f386b67c6b7e3262c45"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.0"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
-LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
+LossFunctions = "6e9bb92d-87bd-4e8a-b639-80472d1675c6"
 
 [compat]
 Documenter = "0.23"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
+LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
+
+[compat]
+Documenter = "0.23"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,17 +1,13 @@
 using Documenter, LearnBase, LossFunctions
 
+istravis = "TRAVIS" ∈ keys(ENV)
+
 makedocs(
     modules = [LossFunctions, LearnBase],
-    clean = false,
-    format = :html,
-    assets = [
-        joinpath("assets", "favicon.ico"),
-        joinpath("assets", "style.css"),
-    ],
+    format = Documenter.HTML(assets=["assets/style.css","assets/favicon.ico"], prettyurls=istravis),
     sitename = "LossFunctions.jl",
     authors = "Christof Stocker, Tom Breloff, Alex Williams",
-    linkcheck = !("skiplinks" in ARGS),
-    pages = Any[
+    pages = [
         hide("Home" => "index.md"),
         "Introduction" => [
             "introduction/gettingstarted.md",
@@ -24,6 +20,7 @@ makedocs(
         "Available Losses" => [
             "losses/distance.md",
             "losses/margin.md",
+            "losses/other.md",
         ],
         "Advances Topics" => [
             "advanced/extend.md",
@@ -33,13 +30,6 @@ makedocs(
         "acknowledgements.md",
         "LICENSE.md",
     ],
-    html_prettyurls = !("local" in ARGS),
 )
 
-deploydocs(
-    repo = "github.com/JuliaML/LossFunctions.jl.git",
-    target = "build",
-    julia = "0.7",
-    deps = nothing,
-    make = nothing,
-)
+deploydocs(repo="github.com/JuliaML/LossFunctions.jl.git")

--- a/docs/src/losses/distance.md
+++ b/docs/src/losses/distance.md
@@ -1,12 +1,3 @@
-```@meta
-DocTestSetup = quote
-    using LossFunctions
-end
-```
-```@raw html
-<div class="loss-docs">
-```
-
 # Distance-based Losses
 
 Loss functions that belong to the category "distance-based" are

--- a/docs/src/losses/margin.md
+++ b/docs/src/losses/margin.md
@@ -1,12 +1,3 @@
-```@meta
-DocTestSetup = quote
-    using LossFunctions
-end
-```
-```@raw html
-<div class="loss-docs">
-```
-
 # Margin-based Losses
 
 Margin-based loss functions are particularly useful for binary

--- a/docs/src/losses/other.md
+++ b/docs/src/losses/other.md
@@ -1,0 +1,22 @@
+# Other Losses
+
+Loss functions exist that are not based on distances nor margins. This section
+lists other useful losses that are implemented in the package:
+
+## MisclassLoss
+
+```@docs
+MisclassLoss
+```
+
+## PoissonLoss
+
+```@docs
+PoissonLoss
+```
+
+## CrossEntropyLoss
+
+```@docs
+CrossEntropyLoss
+```

--- a/docs/src/user/aggregate.md
+++ b/docs/src/user/aggregate.md
@@ -1,9 +1,3 @@
-```@meta
-DocTestSetup = quote
-    using LossFunctions
-end
-```
-
 # Efficient Sum and Mean
 
 In many situations we are not really that interested in the

--- a/docs/src/user/interface.md
+++ b/docs/src/user/interface.md
@@ -1,9 +1,3 @@
-```@meta
-DocTestSetup = quote
-    using LossFunctions
-end
-```
-
 # Working with Losses
 
 Even though they are called loss "functions", this package


### PR DESCRIPTION
This PR updates the docs to use Project.toml and a newer version of Documenter.jl. It also adds a new subsection covering the other losses available that do not fit the distance-based nor margin-based definition.

Fix #111 