### PR TITLE
Update plot recipe

### DIFF
--- a/docs/src/introduction/gettingstarted.md
+++ b/docs/src/introduction/gettingstarted.md
@@ -113,10 +113,10 @@ avoid allocating a temporary array and directly compute the
 result.
 
 ```julia-repl
-julia> value(L2DistLoss(), true_targets, pred_outputs, AvgMode.Sum())
+julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.Sum())
 5.25
 
-julia> value(L2DistLoss(), true_targets, pred_outputs, AvgMode.Mean())
+julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.Mean())
 1.75
 ```
 
@@ -126,10 +126,10 @@ each observation in the predicted outputs and so allow to give
 certain observations a stronger influence over the result.
 
 ```julia-repl
-julia> value(L2DistLoss(), true_targets, pred_outputs, AvgMode.WeightedSum([2,1,1]))
+julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.WeightedSum([2,1,1]))
 5.5
 
-julia> value(L2DistLoss(), true_targets, pred_outputs, AvgMode.WeightedMean([2,1,1]))
+julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.WeightedMean([2,1,1]))
 1.375
 ```
 
@@ -157,7 +157,7 @@ julia> value(L2DistLoss(), A, B)
  0.00161395  0.0423701  0.183882
  0.172286    0.0180639  0.00252607
 
-julia> value(L2DistLoss(), A, B, AvgMode.Sum())
+julia> value(L2DistLoss(), A, B, AggMode.Sum())
 0.420741920634
 ```
 
@@ -172,7 +172,7 @@ julia> value(L2DistLoss(), rand(2), rand(2,2))
  0.228077  0.597212
  0.789808  0.311914
 
-julia> value(L2DistLoss(), rand(2), rand(2,2), AvgMode.Sum())
+julia> value(L2DistLoss(), rand(2), rand(2,2), AggMode.Sum())
 0.0860658081865589
 ```
 
@@ -182,18 +182,18 @@ multivariate regression where one could want to accumulate the
 loss per individual observation.
 
 ```julia-repl
-julia> value(L2DistLoss(), A, B, AvgMode.Sum(), ObsDim.First())
+julia> value(L2DistLoss(), A, B, AggMode.Sum(), ObsDim.First())
 2-element Array{Float64,1}:
  0.227866
  0.192876
 
-julia> value(L2DistLoss(), A, B, AvgMode.Sum(), ObsDim.Last())
+julia> value(L2DistLoss(), A, B, AggMode.Sum(), ObsDim.Last())
 3-element Array{Float64,1}:
  0.1739
  0.060434
  0.186408
 
-julia> value(L2DistLoss(), A, B, AvgMode.WeightedSum([2,1]), ObsDim.First())
+julia> value(L2DistLoss(), A, B, AggMode.WeightedSum([2,1]), ObsDim.First())
 0.648608280735
 ```
 
@@ -287,4 +287,3 @@ If you encounter a bug or would like to participate in the
 further development of this package come find us on Github.
 
 - [JuliaML/LossFunctions.jl](https://github.com/JuliaML/LossFunctions.jl)
-

--- a/docs/src/user/interface.md
+++ b/docs/src/user/interface.md
@@ -1,3 +1,9 @@
+```@meta
+DocTestSetup = quote
+    using LossFunctions
+end
+```
+
 # Working with Losses
 
 Even though they are called loss "functions", this package

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -82,7 +82,7 @@ export
 
     AggMode
 
-include("common.jl")
+include("devutils.jl")
 include("aggregatemode.jl")
 
 include("supervised/supervised.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,9 +1,0 @@
-macro _not_implemented()
-    quote
-        throw(ArgumentError("Not implemented for the given type"))
-    end
-end
-
-macro _dimcheck(condition)
-    :(($(esc(condition))) || throw(DimensionMismatch("Dimensions of the parameters don't match: $($(string(condition)))")))
-end

--- a/src/devutils.jl
+++ b/src/devutils.jl
@@ -1,0 +1,3 @@
+macro dimcheck(condition)
+    :(($(esc(condition))) || throw(DimensionMismatch("Dimensions of the parameters don't match: $($(string(condition)))")))
+end

--- a/src/supervised/io.jl
+++ b/src/supervised/io.jl
@@ -33,10 +33,11 @@ Base.print(io::IO, loss::WeightedBinaryLoss{T,W}, args...) where {T,W} = print(i
 
 _loss_xguide(loss::MarginLoss) = "y * h(x)"
 _loss_xguide(loss::DistanceLoss) = "h(x) - y"
+_loss_yguide(loss::SupervisedLoss) = "L("*_loss_xguide(loss)*")"
 
-@recipe function plot(loss::SupervisedLoss, range = -2:0.05:2; fun=value)
+@recipe function plot(loss::SupervisedLoss, range=-2:0.05:2; fun=value)
     xguide --> _loss_xguide(loss)
-    yguide --> "L(y, h(x))"
+    yguide --> _loss_yguide(loss)
     label  --> string(loss)
     l(a) = fun(loss, a)
     l, range

--- a/src/supervised/io.jl
+++ b/src/supervised/io.jl
@@ -34,32 +34,10 @@ Base.print(io::IO, loss::WeightedBinaryLoss{T,W}, args...) where {T,W} = print(i
 _loss_xguide(loss::MarginLoss) = "y * h(x)"
 _loss_xguide(loss::DistanceLoss) = "h(x) - y"
 
-@recipe function plot(drv::Deriv, rng = -2:0.05:2)
-    xguide --> _loss_xguide(drv.loss)
-    yguide --> "L'(y, h(x))"
-    label  --> string(drv.loss)
-    deriv_fun(drv.loss), rng
-end
-
-@recipe function plot(loss::SupervisedLoss, rng = -2:0.05:2)
+@recipe function plot(loss::SupervisedLoss, range = -2:0.05:2; fun=value)
     xguide --> _loss_xguide(loss)
     yguide --> "L(y, h(x))"
     label  --> string(loss)
-    value_fun(loss), rng
-end
-
-@recipe function plot(derivs::AbstractVector{T}, rng = -2:0.05:2) where T<:Deriv
-    for drv in derivs
-        @series begin
-            drv, rng
-        end
-    end
-end
-
-@recipe function plot(losses::AbstractVector{T}, rng = -2:0.05:2) where T<:SupervisedLoss
-    for loss in losses
-        @series begin
-            loss, rng
-        end
-    end
+    l(a) = fun(loss, a)
+    l, range
 end

--- a/src/supervised/sparse.jl
+++ b/src/supervised/sparse.jl
@@ -19,8 +19,8 @@ end
     ) where {T,N,Q,Ti,M}
     M > N && throw(ArgumentError("target has more dimensions than output; broadcasting not supported in this direction."))
     quote
-      @_dimcheck size(buffer) == size(output)
-      @nexprs $M (n)->@_dimcheck(size(target,n) == size(output,n))
+      @dimcheck size(buffer) == size(output)
+      @nexprs $M (n)->@dimcheck(size(target,n) == size(output,n))
       zeroQ = zero(Q)
       negQ = Q(-1)
       @simd for I in CartesianIndices(size(output))


### PR DESCRIPTION
This PR addresses item (3) of issue #126. It gets rid of the internal `Deriv` and `Deriv2` types previously used to define plot recipes. The new plot recipe is simpler and we can plot different traits of the loss by passing a keyword argument:

```julia
using LossFunctions
using Plots

l = L2DistLoss()

plot(l) # default to value
plot(l, fun=deriv) # equivalent to old Deriv
plot(l, fun=deriv2) # equivalent to old Deriv2
```

As a side note, the plot recipe is not covered by the current test suite. In my own packages I make use of VisualRegressionTests.jl for testing plot recipes. Would you be ok with adding it here as a test dependency as well?