### PR TITLE
Add support for CategoricalArrays.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 LearnBase = "0.4"
 RecipesBase = "0.8, 1.0"
-StatsBase = "0.33"
+StatsBase = "0.32, 0.33"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 version = "0.6.0"
 
 [deps]
-CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -11,17 +10,17 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-CategoricalArrays = "0.8"
 LearnBase = "0.4"
 RecipesBase = "0.8, 1.0"
 StatsBase = "0.33"
 julia = "1"
 
 [extras]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DualNumbers = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DualNumbers", "Random", "Statistics", "Test"]
+test = ["CategoricalArrays", "DualNumbers", "Random", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 version = "0.6.0"
 
 [deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -11,7 +11,8 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-LearnBase = "0.3"
+CategoricalArrays = "0.8"
+LearnBase = "0.4"
 RecipesBase = "0.8, 1.0"
 StatsBase = "0.33"
 julia = "1"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -76,7 +76,7 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 [[LossFunctions]]
 deps = ["CategoricalArrays", "LearnBase", "Markdown", "RecipesBase", "SparseArrays", "StatsBase"]
 path = ".."
-uuid = "6e9bb92d-87bd-4e8a-b639-80472d1675c6"
+uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 version = "0.6.0"
 
 [[Markdown]]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -3,16 +3,22 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[CategoricalArrays]]
+deps = ["DataAPI", "Future", "JSON", "Missings", "Printf", "Statistics", "Unicode"]
+git-tree-sha1 = "df774d7e905ca391178f0abc67f4fa5d3ff4ef12"
+uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+version = "0.8.0"
+
 [[DataAPI]]
-git-tree-sha1 = "674b67f344687a88310213ddfa8a2b3c76cc4252"
+git-tree-sha1 = "00612b2fbe534a539dc7f70106c71e3a943d9b98"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.1.0"
+version = "1.2.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "73eb18320fe3ba58790c8b8f6f89420f0a622773"
+git-tree-sha1 = "9faa13be79557bf4c5713fb912b0e3c5aa33d046"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.11"
+version = "0.17.13"
 
 [[Dates]]
 deps = ["Printf"]
@@ -34,6 +40,10 @@ git-tree-sha1 = "d45c163c7a3ae293c15361acc52882c0f853f97c"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.23.4"
 
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -45,12 +55,12 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.0"
 
 [[LearnBase]]
-deps = ["LinearAlgebra", "StatsBase"]
-git-tree-sha1 = "47e6f4623c1db88570c7a7fa66c6528b92ba4725"
+git-tree-sha1 = "a9bd0fb1b2774939400e5e604f94aa3ae070cdf1"
 uuid = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
-version = "0.3.0"
+version = "0.4.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]
@@ -64,10 +74,10 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[LossFunctions]]
-deps = ["InteractiveUtils", "LearnBase", "Markdown", "RecipesBase", "SparseArrays", "StatsBase"]
+deps = ["CategoricalArrays", "LearnBase", "Markdown", "RecipesBase", "SparseArrays", "StatsBase"]
 path = ".."
 uuid = "6e9bb92d-87bd-4e8a-b639-80472d1675c6"
-version = "0.5.2"
+version = "0.6.0"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -90,12 +100,12 @@ version = "1.1.0"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "75d07cb840c300084634b4991761886d0d762724"
+git-tree-sha1 = "f8f5d2d4b4b07342e5811d2b6428e45524e241df"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.1"
+version = "1.0.2"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -111,9 +121,9 @@ deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RecipesBase]]
-git-tree-sha1 = "b4ed4a7f988ea2340017916f7c9e5d7560b52cae"
+git-tree-sha1 = "d352369b00094cadb43d694333b051b3d55abaf2"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "0.8.0"
+version = "1.0.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LearnBase = "7f8f8fb0-2700-5f03-b4bd-41f8cfc144b6"
-LossFunctions = "6e9bb92d-87bd-4e8a-b639-80472d1675c6"
+LossFunctions = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
 
 [compat]
 Documenter = "0.23"

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -4,7 +4,6 @@ import Base.*
 using Base.Cartesian
 using Markdown
 using SparseArrays
-using CategoricalArrays
 using RecipesBase
 
 import LearnBase.AggMode

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -34,6 +34,7 @@ include("plotrecipes.jl")
 
 # deprecations
 @deprecate LogitProbLoss CrossEntropyLoss
+@deprecate PinballLoss QuantileLoss
 @deprecate OrdinalHingeLoss OrdinalMarginLoss{HingeLoss}
 @deprecate weightedloss(l, w) WeightedMarginLoss(l, w)
 @deprecate scaled(l, λ) ScaledLoss(l, λ)
@@ -85,7 +86,6 @@ export
     L2EpsilonInsLoss,
     LogitDistLoss,
     QuantileLoss,
-    PinballLoss,
 
     # other losses
     MisclassLoss,

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -4,7 +4,7 @@ import Base.*
 using Base.Cartesian
 using Markdown
 using SparseArrays
-using InteractiveUtils
+using CategoricalArrays
 using RecipesBase
 
 import LearnBase.AggMode
@@ -25,9 +25,6 @@ import LearnBase:
     islipschitzcont, islocallylipschitzcont,
     isclipable, isclasscalibrated, issymmetric
 
-# for maintainers
-include("devutils.jl")
-
 # supervised losses
 include("supervised.jl")
 
@@ -36,6 +33,7 @@ include("printing.jl")
 include("plotrecipes.jl")
 
 # deprecations
+@deprecate LogitProbLoss CrossEntropyLoss
 @deprecate OrdinalHingeLoss OrdinalMarginLoss{HingeLoss}
 @deprecate weightedloss(l, w) WeightedMarginLoss(l, w)
 @deprecate scaled(l, λ) ScaledLoss(l, λ)
@@ -92,7 +90,6 @@ export
     # other losses
     MisclassLoss,
     PoissonLoss,
-    LogitProbLoss,
     CrossEntropyLoss,
 
     # meta losses

--- a/src/devutils.jl
+++ b/src/devutils.jl
@@ -1,3 +1,0 @@
-macro dimcheck(condition)
-    :(($(esc(condition))) || throw(DimensionMismatch("Dimensions of the parameters don't match: $($(string(condition)))")))
-end

--- a/src/supervised.jl
+++ b/src/supervised.jl
@@ -11,8 +11,7 @@ deriv(loss::MarginLoss, target::Number, output::Number)  = target * deriv(loss, 
 deriv2(loss::MarginLoss, target::Number, output::Number) = deriv2(loss, target * output)
 
 # result type when applying the loss to a single pair of objects
-result_type(loss::SupervisedLoss, t::Type{T}, o::Type{O}) where {T,O} = typeof(value(loss, zero(t), zero(o)))
-result_type(loss::SupervisedLoss, t::Type{<:CategoricalValue}, o::Type{<:CategoricalValue}) = Float64
+result_type(loss::SupervisedLoss, t::Type, o::Type) = typeof(value(loss, zero(t), zero(o)))
 
 # ------------------
 # AVAILABLE LOSSES

--- a/src/supervised.jl
+++ b/src/supervised.jl
@@ -22,6 +22,11 @@ include("supervised/ordinal.jl")
 include("supervised/scaled.jl")
 include("supervised/weighted.jl")
 
+# helper macro (for devs)
+macro dimcheck(condition)
+    :(($(esc(condition))) || throw(DimensionMismatch("Dimensions of the parameters don't match: $($(string(condition)))")))
+end
+
 # ------------------------------
 # DEFAULT AGGREGATION BEHAVIOR
 # ------------------------------

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -458,8 +458,6 @@ struct QuantileLoss{T <: AbstractFloat} <: DistanceLoss
     τ::T
 end
 
-const PinballLoss = QuantileLoss
-
 function value(loss::QuantileLoss{T1}, diff::T2) where {T1, T2 <: Number}
     T = promote_type(T1, T2)
     diff * (convert(T,diff > 0) - loss.τ)

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -12,9 +12,6 @@ struct MisclassLoss{R<:AbstractFloat} <: SupervisedLoss end
 
 MisclassLoss() = MisclassLoss{Float64}()
 
-# categorical + numerical type
-const NUM = Union{CategoricalValue,Number}
-
 # specialize result type
 result_type(loss::MisclassLoss{R}, t::Type, o::Type) where R = R
 
@@ -23,9 +20,82 @@ value(::MisclassLoss{R}, agreement::Bool) where R = ifelse(agreement, zero(R), o
 deriv(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 deriv2(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 
-value(loss::MisclassLoss, target::NUM, output::NUM) = value(loss, target == output)
-deriv(loss::MisclassLoss, target::NUM, output::NUM) = deriv(loss, target == output)
-deriv2(loss::MisclassLoss, target::NUM, output::NUM) = deriv2(loss, target == output)
+value(loss::MisclassLoss, target, output) = value(loss, target == output)
+deriv(loss::MisclassLoss, target, output) = deriv(loss, target == output)
+deriv2(loss::MisclassLoss, target, output) = deriv2(loss, target == output)
+
+# specialize aggregation methods (temporary workaround)
+for FUN in (:value, :deriv, :deriv2)
+    @eval begin
+        # by default compute the element-wise result
+        function ($FUN)(
+                loss::MisclassLoss,
+                targets::AbstractVector,
+                outputs::AbstractVector)
+            ($FUN)(loss, targets, outputs, AggMode.None())
+        end
+
+        function ($FUN)(
+                loss::MisclassLoss,
+                targets::AbstractVector,
+                outputs::AbstractVector,
+                ::AggMode.None)
+            ($FUN).(loss, targets, outputs)
+        end
+
+        function ($FUN)(
+                loss::MisclassLoss,
+                targets::AbstractVector{Q},
+                outputs::AbstractVector{T},
+                ::AggMode.Sum) where {Q,T}
+            out = zero(result_type(loss, Q, T))
+            @inbounds @simd for I in CartesianIndices(size(outputs))
+                out += ($FUN)(loss, targets[I], outputs[I])
+            end
+            out
+        end
+
+        function ($FUN)(
+                loss::MisclassLoss,
+                targets::AbstractVector{Q},
+                outputs::AbstractVector{T},
+                ::AggMode.Mean) where {Q,T}
+            nrm = length(targets)
+            out = zero(result_type(loss, Q, T))
+            @inbounds @simd for I in CartesianIndices(size(outputs))
+                out += ($FUN)(loss, targets[I], outputs[I])
+            end
+            out / nrm
+        end
+
+        function ($FUN)(
+                loss::MisclassLoss,
+                targets::AbstractVector{Q},
+                outputs::AbstractVector{T},
+                agg::AggMode.WeightedSum) where {Q,T}
+            nrm = agg.normalize ? inv(sum(agg.weights)) : inv(one(sum(agg.weights)))
+            out = zero(result_type(loss, Q, T)) * (agg.weights[1] * nrm)
+            @inbounds @simd for I in CartesianIndices(size(outputs))
+                out += ($FUN)(loss, targets[I], outputs[I]) * (agg.weights[I] * nrm)
+            end
+            out
+        end
+
+        function ($FUN)(
+                loss::MisclassLoss,
+                targets::AbstractVector{Q},
+                outputs::AbstractVector{T},
+                agg::AggMode.WeightedMean) where {Q,T}
+            k   = length(outputs)
+            nrm = agg.normalize ? inv(k * sum(agg.weights)) : inv(k * one(sum(agg.weights)))
+            out = zero(result_type(loss, Q, T)) * (agg.weights[1] * nrm)
+            @inbounds @simd for I in CartesianIndices(size(outputs))
+                out += ($FUN)(loss, targets[I], outputs[I]) * (agg.weights[I] * nrm)
+            end
+            out
+        end
+    end
+end
 
 isminimizable(::MisclassLoss) = false
 isdifferentiable(::MisclassLoss) = false

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -1,18 +1,27 @@
 @doc doc"""
-    MisclassLoss <: SupervisedLoss
+    MisclassLoss{R<:AbstractFloat} <: SupervisedLoss
 
 Misclassification loss that assigns `1` for misclassified
 examples and `0` otherwise. It is a generalization of
 `ZeroOneLoss` for more than two classes.
+
+The type parameter `R` specifies the result type of the
+loss. Default type is double precision `R = Float64`.
 """
-struct MisclassLoss <: SupervisedLoss end
+struct MisclassLoss{R<:AbstractFloat} <: SupervisedLoss end
+
+MisclassLoss() = MisclassLoss{Float64}()
+
+# categorical + numerical type
+const CV = Union{CategoricalValue,Number}
+
+# specialize result type
+result_type(loss::MisclassLoss{R}, t::Type{T}, o::Type{O}) where {R,T,O} = R
 
 # return floating point to avoid big integers in aggregations
-value(::MisclassLoss, agreement::Bool) = ifelse(agreement, 0.0, 1.0)
-deriv(::MisclassLoss, agreement::Bool) = 0.0
-deriv2(::MisclassLoss, agreement::Bool) = 0.0
-
-const CV = Union{CategoricalValue,Number}
+value(::MisclassLoss{R}, agreement::Bool) where R = ifelse(agreement, zero(R), one(R))
+deriv(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
+deriv2(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 
 value(loss::MisclassLoss, target::CV, output::CV) = value(loss, target == output)
 deriv(loss::MisclassLoss, target::CV, output::CV) = deriv(loss, target == output)

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -13,19 +13,19 @@ struct MisclassLoss{R<:AbstractFloat} <: SupervisedLoss end
 MisclassLoss() = MisclassLoss{Float64}()
 
 # categorical + numerical type
-const CV = Union{CategoricalValue,Number}
+const NUM = Union{CategoricalValue,Number}
 
 # specialize result type
-result_type(loss::MisclassLoss{R}, t::Type{T}, o::Type{O}) where {R,T,O} = R
+result_type(loss::MisclassLoss{R}, t::Type, o::Type) where R = R
 
 # return floating point to avoid big integers in aggregations
 value(::MisclassLoss{R}, agreement::Bool) where R = ifelse(agreement, zero(R), one(R))
 deriv(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 deriv2(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 
-value(loss::MisclassLoss, target::CV, output::CV) = value(loss, target == output)
-deriv(loss::MisclassLoss, target::CV, output::CV) = deriv(loss, target == output)
-deriv2(loss::MisclassLoss, target::CV, output::CV) = deriv2(loss, target == output)
+value(loss::MisclassLoss, target::NUM, output::NUM) = value(loss, target == output)
+deriv(loss::MisclassLoss, target::NUM, output::NUM) = deriv(loss, target == output)
+deriv2(loss::MisclassLoss, target::NUM, output::NUM) = deriv2(loss, target == output)
 
 isminimizable(::MisclassLoss) = false
 isdifferentiable(::MisclassLoss) = false

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -7,15 +7,15 @@ examples and `0` otherwise. It is a generalization of
 """
 struct MisclassLoss <: SupervisedLoss end
 
-agreement(target, output) = target == output
-
-value(::MisclassLoss, agreement::Bool) = agreement ? 0 : 1
+value(::MisclassLoss, agreement::Bool) = ifelse(agreement, 0, 1)
 deriv(::MisclassLoss, agreement::Bool) = 0
 deriv2(::MisclassLoss, agreement::Bool) = 0
 
-value(loss::MisclassLoss, target::Number, output::Number) = value(loss, agreement(target, output))
-deriv(loss::MisclassLoss, target::Number, output::Number) = deriv(loss, agreement(target, output))
-deriv2(loss::MisclassLoss, target::Number, output::Number) = deriv2(loss, agreement(target, output))
+const CV = Union{CategoricalValue,Number}
+
+value(loss::MisclassLoss, target::CV, output::CV) = value(loss, target == output)
+deriv(loss::MisclassLoss, target::CV, output::CV) = deriv(loss, target == output)
+deriv2(loss::MisclassLoss, target::CV, output::CV) = deriv2(loss, target == output)
 
 isminimizable(::MisclassLoss) = false
 isdifferentiable(::MisclassLoss) = false
@@ -62,7 +62,6 @@ Cross-entropy loss also known as log loss and logistic loss is defined as:
 ``L(target, output) = - target*ln(output) - (1-target)*ln(1-output)``
 """
 struct CrossEntropyLoss <: SupervisedLoss end
-const LogitProbLoss = CrossEntropyLoss
 
 function value(loss::CrossEntropyLoss, target::Number, output::Number)
     target >= 0 && target <=1 || error("target must be in [0,1]")

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -7,9 +7,10 @@ examples and `0` otherwise. It is a generalization of
 """
 struct MisclassLoss <: SupervisedLoss end
 
-value(::MisclassLoss, agreement::Bool) = ifelse(agreement, 0, 1)
-deriv(::MisclassLoss, agreement::Bool) = 0
-deriv2(::MisclassLoss, agreement::Bool) = 0
+# return floating point to avoid big integers in aggregations
+value(::MisclassLoss, agreement::Bool) = ifelse(agreement, 0.0, 1.0)
+deriv(::MisclassLoss, agreement::Bool) = 0.0
+deriv2(::MisclassLoss, agreement::Bool) = 0.0
 
 const CV = Union{CategoricalValue,Number}
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-DualNumbers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 module LossFunctionsTests
 
 using LossFunctions
+using CategoricalArrays
 using SparseArrays
 using DualNumbers
 using Statistics

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -106,31 +106,31 @@ function test_vector_value(l::DistanceLoss, t, y)
 end
 
 function test_vector_deriv(l::MarginLoss, t, y)
-    ref = [LossFunctions.deriv(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(LossFunctions.deriv(l, t, y, AggMode.None())) == ref
-    @test @inferred(LossFunctions.deriv(l, t, y)) == ref
-    @test LossFunctions.deriv.(Ref(l), t, y) == ref
+    ref = [deriv(l,t[i],y[i]) for i in CartesianIndices(size(y))]
+    @test @inferred(deriv(l, t, y, AggMode.None())) == ref
+    @test @inferred(deriv(l, t, y)) == ref
+    @test deriv.(Ref(l), t, y) == ref
 end
 
 function test_vector_deriv(l::DistanceLoss, t, y)
-    ref = [LossFunctions.deriv(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(LossFunctions.deriv(l, t, y, AggMode.None())) == ref
-    @test @inferred(LossFunctions.deriv(l, t, y)) == ref
-    @test LossFunctions.deriv.(Ref(l), t, y) == ref
+    ref = [deriv(l,t[i],y[i]) for i in CartesianIndices(size(y))]
+    @test @inferred(deriv(l, t, y, AggMode.None())) == ref
+    @test @inferred(deriv(l, t, y)) == ref
+    @test deriv.(Ref(l), t, y) == ref
 end
 
 function test_vector_deriv2(l::MarginLoss, t, y)
-    ref = [LossFunctions.deriv2(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(LossFunctions.deriv2(l, t, y, AggMode.None())) == ref
-    @test @inferred(LossFunctions.deriv2(l, t, y)) == ref
-    @test LossFunctions.deriv2.(Ref(l), t, y) == ref
+    ref = [deriv2(l,t[i],y[i]) for i in CartesianIndices(size(y))]
+    @test @inferred(deriv2(l, t, y, AggMode.None())) == ref
+    @test @inferred(deriv2(l, t, y)) == ref
+    @test deriv2.(Ref(l), t, y) == ref
 end
 
 function test_vector_deriv2(l::DistanceLoss, t, y)
-    ref = [LossFunctions.deriv2(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(LossFunctions.deriv2(l, t, y, AggMode.None())) == ref
-    @test @inferred(LossFunctions.deriv2(l, t, y)) == ref
-    @test LossFunctions.deriv2.(Ref(l), t, y) == ref
+    ref = [deriv2(l,t[i],y[i]) for i in CartesianIndices(size(y))]
+    @test @inferred(deriv2(l, t, y, AggMode.None())) == ref
+    @test @inferred(deriv2(l, t, y)) == ref
+    @test deriv2.(Ref(l), t, y) == ref
 end
 
 @testset "Vectorized API" begin

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -481,6 +481,10 @@ end
     @test value(l, c, reverse(c), AggMode.Mean()) == 0.5
     @test value(l, c, reverse(c), AggMode.WeightedSum(2*ones(4))) == 4.0
     @test value(l, c, reverse(c), AggMode.WeightedMean(2*ones(4))) == 0.5
+
+    lf = MisclassLoss{Float32}()
+    @test value(lf, c[1], c[1]) isa Float32
+    @test value(lf, c, c) isa Vector{Float32}
 end
 
 # --------------------------------------------------------------

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -480,7 +480,8 @@ end
     @test value(l, c, reverse(c), AggMode.Sum()) == 2.0
     @test value(l, c, reverse(c), AggMode.Mean()) == 0.5
     @test value(l, c, reverse(c), AggMode.WeightedSum(2*ones(4))) == 4.0
-    @test value(l, c, reverse(c), AggMode.WeightedMean(2*ones(4))) == 0.5
+    @test value(l, c, reverse(c), AggMode.WeightedMean(2*ones(4),false)) == 1.0
+    @test value(l, c, reverse(c), AggMode.WeightedMean(2*ones(4),true)) == 0.125
 
     lf = MisclassLoss{Float32}()
     @test value(lf, c[1], c[1]) isa Float32

--- a/test/tst_properties.jl
+++ b/test/tst_properties.jl
@@ -680,30 +680,21 @@ end
 compare_losses(PoissonLoss(), 2*PoissonLoss())
 compare_losses(PoissonLoss(), 0.5*PoissonLoss())
 
+@testset "Scaled losses" begin
+    for loss in distance_losses ∪ margin_losses ∪ other_losses
+        @testset "$loss" begin
+            compare_losses(loss, 2*loss)
+            compare_losses(loss, 0.5*loss)
+        end
+    end
+end
+
 @testset "Weighted Margin-based" begin
     for loss in margin_losses
         @testset "$loss" begin
             compare_losses(loss, WeightedMarginLoss(loss,0.2), false)
             compare_losses(loss, WeightedMarginLoss(loss,0.5), true)
             compare_losses(loss, WeightedMarginLoss(loss,0.7), false)
-        end
-    end
-end
-
-@testset "Scaled Margin-based" begin
-    for loss in margin_losses
-        @testset "$loss" begin
-            compare_losses(loss, 2*loss)
-            compare_losses(loss, 0.5*loss)
-        end
-    end
-end
-
-@testset "Scaled Distance-based" begin
-    for loss in distance_losses
-        @testset "$loss" begin
-            compare_losses(loss, 2*loss)
-            compare_losses(loss, 0.5*loss)
         end
     end
 end


### PR DESCRIPTION
This PR is work-in-progress. It attempts to generalize the functionality of the package to support `CategoricalArray` and `CategoricalValue` from CategoricalArrays.jl. Fix #117.

I will share a comment here when it is ready for review.