### PR TITLE
remove unneeded generated function for OrdinalMarginLoss constructor

### DIFF
--- a/src/supervised/ordinal.jl
+++ b/src/supervised/ordinal.jl
@@ -19,9 +19,9 @@ function OrdinalMarginLoss(loss::L, N::Int) where {L<:MarginLoss}
     OrdinalMarginLoss{L}(loss, N)
 end
 
-@generated function (::Type{T})(N::Int, args...) where {T<:OrdinalMarginLoss}
-    L = typeof(T) == UnionAll ? T.var.ub : T.parameters[1]
-    :(OrdinalMarginLoss($L(args...), N))
+function (::Type{T})(N::Int, args...) where {T<:OrdinalMarginLoss}
+    L = fieldtype(T, 1)
+    OrdinalMarginLoss(L(args...), N)
 end
 
 for fun in (:value, :deriv, :deriv2)


### PR DESCRIPTION
The normal lowering for this function uses `fieldtype`, just like this, which does not suffer from the assumption mistakes of the `@generated` approximation of this of how to unwrap and normalize types correctly.