### PR TITLE
Revert order of arguments

### DIFF
--- a/docs/src/advanced/extend.md
+++ b/docs/src/advanced/extend.md
@@ -42,10 +42,10 @@ ScaledLoss
 julia> lsloss = 1/2 * L2DistLoss()
 ScaledLoss{L2DistLoss, 0.5}(L2DistLoss())
 
-julia> value(L2DistLoss(), 0.0, 4.0)
+julia> value(L2DistLoss(), 4.0, 0.0)
 16.0
 
-julia> value(lsloss, 0.0, 4.0)
+julia> value(lsloss, 4.0, 0.0)
 8.0
 ```
 
@@ -102,16 +102,16 @@ WeightedMarginLoss
 julia> myloss = WeightedMarginLoss(HingeLoss(), 0.8)
 WeightedMarginLoss{L1HingeLoss, 0.8}(L1HingeLoss())
 
-julia> value(myloss, 1.0, -4.0) # positive class
+julia> value(myloss, -4.0, 1.0) # positive class
 4.0
 
-julia> value(HingeLoss(), 1.0, -4.0)
+julia> value(HingeLoss(), -4.0, 1.0)
 5.0
 
-julia> value(myloss, -1.0, 4.0) # negative class
+julia> value(myloss, 4.0, -1.0) # negative class
 0.9999999999999998
 
-julia> value(HingeLoss(), -1.0, 4.0)
+julia> value(HingeLoss(), 4.0, -1.0)
 5.0
 ```
 

--- a/docs/src/introduction/gettingstarted.md
+++ b/docs/src/introduction/gettingstarted.md
@@ -48,7 +48,7 @@ The true targets are often expected to be of a specific set (e.g.
 So for our purposes we can define a supervised loss as follows
 
 ```math
-L : Y \times \mathbb{R} \rightarrow [0,\infty)
+L : \mathbb{R} \times Y \rightarrow [0,\infty)
 ```
 
 Such a loss function takes these two variables as input and
@@ -64,8 +64,8 @@ the function [`value`](@ref). Let us start with an example of how
 to compute the loss of a single observation (i.e. two numbers).
 
 ```julia-repl
-#                loss       y    ŷ
-julia> value(L2DistLoss(), 1.0, 0.5)
+#                loss       ŷ    y
+julia> value(L2DistLoss(), 0.5, 1.0)
 0.25
 ```
 
@@ -78,7 +78,7 @@ julia> true_targets = [  1,  0, -2];
 
 julia> pred_outputs = [0.5,  2, -1];
 
-julia> value(L2DistLoss(), true_targets, pred_outputs)
+julia> value(L2DistLoss(), pred_outputs, true_targets)
 3-element Array{Float64,1}:
  0.25
  4.0
@@ -92,10 +92,10 @@ This will avoid allocating a temporary array and directly
 compute the result.
 
 ```julia-repl
-julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.Sum())
+julia> value(L2DistLoss(), pred_outputs, true_targets, AggMode.Sum())
 5.25
 
-julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.Mean())
+julia> value(L2DistLoss(), pred_outputs, true_targets, AggMode.Mean())
 1.75
 ```
 
@@ -105,54 +105,11 @@ each observation in the predicted outputs and so allow to give
 certain observations a stronger influence over the result.
 
 ```julia-repl
-julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.WeightedSum([2,1,1]))
+julia> value(L2DistLoss(), pred_outputs, true_targets, AggMode.WeightedSum([2,1,1]))
 5.5
 
-julia> value(L2DistLoss(), true_targets, pred_outputs, AggMode.WeightedMean([2,1,1]))
+julia> value(L2DistLoss(), pred_outputs, true_targets, AggMode.WeightedMean([2,1,1]))
 1.375
-```
-
-We do not restrict the targets and outputs to be vectors, but
-instead allow them to be arrays of any arbitrary shape. The shape
-of an array may or may not have an interpretation that is
-relevant for computing the loss. Consequently, those methods that
-don't require this information can be invoked using the same
-method signature as before, because the results are simply
-computed element-wise or accumulated.
-
-```julia-repl
-julia> A = rand(2,3)
-2×3 Array{Float64,2}:
- 0.0939946  0.97639   0.568107
- 0.183244   0.854832  0.962534
-
-julia> B = rand(2,3)
-2×3 Array{Float64,2}:
- 0.0538206  0.77055  0.996922
- 0.598317   0.72043  0.912274
-
-julia> value(L2DistLoss(), A, B)
-2×3 Array{Float64,2}:
- 0.00161395  0.0423701  0.183882
- 0.172286    0.0180639  0.00252607
-
-julia> value(L2DistLoss(), A, B, AggMode.Sum())
-0.420741920634
-```
-
-These methods even allow arrays of different dimensionality, in
-which case broadcast is performed. This also applies to computing
-the sum and mean, in which case we use custom broadcast
-implementations that avoid allocating a temporary array.
-
-```julia-repl
-julia> value(L2DistLoss(), rand(2), rand(2,2))
-2×2 Array{Float64,2}:
- 0.228077  0.597212
- 0.789808  0.311914
-
-julia> value(L2DistLoss(), rand(2), rand(2,2), AggMode.Sum())
-0.0860658081865589
 ```
 
 All these function signatures of [`value`](@ref) also apply for
@@ -164,13 +121,13 @@ julia> true_targets = [  1,  0, -2];
 
 julia> pred_outputs = [0.5,  2, -1];
 
-julia> deriv(L2DistLoss(), true_targets, pred_outputs)
+julia> deriv(L2DistLoss(), pred_outputs, true_targets)
 3-element Array{Float64,1}:
  -1.0
   4.0
   2.0
 
-julia> deriv2(L2DistLoss(), true_targets, pred_outputs)
+julia> deriv2(L2DistLoss(), pred_outputs, true_targets)
 3-element Array{Float64,1}:
  2.0
  2.0

--- a/docs/src/introduction/motivation.md
+++ b/docs/src/introduction/motivation.md
@@ -160,7 +160,7 @@ non-negative real number. The larger the value of the loss, the
 worse the prediction.
 
 ```math
-L : Y \times \mathbb{R} \rightarrow [0,\infty)
+L : \mathbb{R} \times Y \rightarrow [0,\infty)
 ```
 
 Note a few interesting things about supervised loss functions.
@@ -205,12 +205,12 @@ other formalism, they do not natively provide probabilities as
 output.
 
 More formally, we call a supervised loss function
-``L : Y \times \mathbb{R} \rightarrow [0, \infty)``
+``L : \mathbb{R} \times Y \rightarrow [0, \infty)``
 **margin-based** if there exists a representing function
 ``\psi : \mathbb{R} \rightarrow [0, \infty)`` such that
 
 ```math
-L(y, \hat{y}) = \psi (y \cdot \hat{y}),  \qquad  y \in Y, \hat{y} \in \mathbb{R}
+L(\hat{y}, y) = \psi (y \cdot \hat{y}),  \qquad  y \in Y, \hat{y} \in \mathbb{R}
 ```
 
 !!! note
@@ -229,13 +229,13 @@ target. In such a scenario it is quite sensible to penalize the
 distance between the prediction and the target in some way.
 
 More formally, a supervised loss function
-``L : Y \times \mathbb{R} \rightarrow [0, \infty)`` is said to be
+``L : \mathbb{R} \times Y \rightarrow [0, \infty)`` is said to be
 **distance-based**, if there exists a representing function
 ``\psi : \mathbb{R} \rightarrow [0, \infty)`` satisfying
 ``\psi (0) = 0`` and
 
 ```math
-L(y, \hat{y}) = \psi (\hat{y} - y),  \qquad  y \in Y, \hat{y} \in \mathbb{R}
+L(\hat{y}, y) = \psi (\hat{y} - y),  \qquad  y \in Y, \hat{y} \in \mathbb{R}
 ```
 
 !!! note

--- a/docs/src/losses/distance.md
+++ b/docs/src/losses/distance.md
@@ -62,6 +62,12 @@ PeriodicLoss
 QuantileLoss
 ```
 
+## LogCoshLoss
+
+```@docs
+LogCoshLoss
+```
+
 !!! note
 
     You may note that our definition of the QuantileLoss looks

--- a/docs/src/user/aggregate.md
+++ b/docs/src/user/aggregate.md
@@ -34,13 +34,13 @@ say "naive", because it will not give us an acceptable
 performance.
 
 ```jldoctest
-julia> value(L1DistLoss(), [1.,2,3], [2,5,-2])
+julia> value(L1DistLoss(), [2,5,-2], [1.,2,3])
 3-element Vector{Float64}:
  1.0
  3.0
  5.0
 
-julia> sum(value(L1DistLoss(), [1.,2,3], [2,5,-2])) # WARNING: Bad code
+julia> sum(value(L1DistLoss(), [2,5,-2], [1.,2,3])) # WARNING: Bad code
 9.0
 ```
 
@@ -109,7 +109,7 @@ the results, we will see that the loss of the second observation
 was effectively counted twice.
 
 ```jldoctest
-julia> result = value.(L1DistLoss(), [1.,2,3], [2,5,-2]) .* [1,2,1]
+julia> result = value.(L1DistLoss(), [2,5,-2], [1.,2,3]) .* [1,2,1]
 3-element Vector{Float64}:
  1.0
  6.0
@@ -154,7 +154,7 @@ julia> outputs = reshape(1:2:16, (2, 4)) ./ 8
 
 julia> # WARNING: BAD CODE - ONLY FOR ILLUSTRATION
 
-julia> tmp = sum(value.(L1DistLoss(), targets, outputs), dims=2)
+julia> tmp = sum(value.(L1DistLoss(), outputs, targets), dims=2)
 2×1 Matrix{Float64}:
  1.5
  2.0
@@ -172,7 +172,7 @@ julia> using Statistics # for access to "mean"
 
 julia> # WARNING: BAD CODE - ONLY FOR ILLUSTRATION
 
-julia> tmp = mean(value.(L1DistLoss(), targets, outputs), dims=2)
+julia> tmp = mean(value.(L1DistLoss(), outputs, targets), dims=2)
 2×1 Matrix{Float64}:
  0.375
  0.5
@@ -195,10 +195,10 @@ special methods for [`value`](@ref), [`deriv`](@ref),
 [`deriv2`](@ref) and their mutating counterparts.
 
 ```jldoctest weight
-julia> value(L1DistLoss(), [1.,2,3], [2,5,-2], AggMode.WeightedSum([1,2,1]))
+julia> value(L1DistLoss(), [2,5,-2], [1.,2,3], AggMode.WeightedSum([1,2,1]))
 12.0
 
-julia> value(L1DistLoss(), [1.,2,3], [2,5,-2], AggMode.WeightedMean([1,2,1]))
+julia> value(L1DistLoss(), [2,5,-2], [1.,2,3], AggMode.WeightedMean([1,2,1]))
 1.0
 ```
 
@@ -206,9 +206,9 @@ We also provide this functionality for [`deriv`](@ref) and
 [`deriv2`](@ref) respectively.
 
 ```jldoctest weight
-julia> deriv(L2DistLoss(), [1.,2,3], [2,5,-2], AggMode.WeightedSum([1,2,1]))
+julia> deriv(L2DistLoss(), [2,5,-2], [1.,2,3], AggMode.WeightedSum([1,2,1]))
 4.0
 
-julia> deriv(L2DistLoss(), [1.,2,3], [2,5,-2], AggMode.WeightedMean([1,2,1]))
+julia> deriv(L2DistLoss(), [2,5,-2], [1.,2,3], AggMode.WeightedMean([1,2,1]))
 0.3333333333333333
 ```

--- a/docs/src/user/interface.md
+++ b/docs/src/user/interface.md
@@ -49,7 +49,7 @@ than one place.
 julia> loss = L2DistLoss()
 L2DistLoss()
 
-julia> value(loss, 2, 3)
+julia> value(loss, 3, 2)
 1
 ```
 
@@ -66,11 +66,11 @@ yourself in the code below. As such they are zero-cost
 abstractions.
 
 ```julia-repl
-julia> v1(loss,t,y) = value(loss,t,y)
+julia> v1(loss,y,t) = value(loss,y,t)
 
-julia> v2(t,y) = value(L2DistLoss(),t,y)
+julia> v2(y,t) = value(L2DistLoss(),y,t)
 
-julia> @code_llvm v1(loss, 2, 3)
+julia> @code_llvm v1(loss, 3, 2)
 define i64 @julia_v1_70944(i64, i64) #0 {
 top:
   %2 = sub i64 %1, %0
@@ -78,7 +78,7 @@ top:
   ret i64 %3
 }
 
-julia> @code_llvm v2(2, 3)
+julia> @code_llvm v2(3, 2)
 define i64 @julia_v2_70949(i64, i64) #0 {
 top:
   %2 = sub i64 %1, %0
@@ -130,7 +130,7 @@ it is quite simple to make use of preallocated memory for storing
 the element-wise results.
 
 ```jldoctest bcast1
-julia> value.(L1DistLoss(), [1,2,3], [2,5,-2])
+julia> value.(L1DistLoss(), [2,5,-2], [1,2,3])
 3-element Vector{Int64}:
  1
  3
@@ -138,7 +138,7 @@ julia> value.(L1DistLoss(), [1,2,3], [2,5,-2])
 
 julia> buffer = zeros(3); # preallocate a buffer
 
-julia> buffer .= value.(L1DistLoss(), [1.,2,3], [2,5,-2])
+julia> buffer .= value.(L1DistLoss(), [2,5,-2], [1.,2,3])
 3-element Vector{Float64}:
  1.0
  3.0
@@ -150,7 +150,7 @@ Julia 0.6, one can also easily weight the influence of each
 observation without allocating a temporary array.
 
 ```jldoctest bcast1
-julia> buffer .= value.(L1DistLoss(), [1.,2,3], [2,5,-2]) .* [2,1,0.5]
+julia> buffer .= value.(L1DistLoss(), [2,5,-2], [1.,2,3]) .* [2,1,0.5]
 3-element Vector{Float64}:
  2.0
  3.0
@@ -182,7 +182,7 @@ one can make use of preallocated memory for storing the
 element-wise derivatives.
 
 ```jldoctest bcast2
-julia> deriv.(L2DistLoss(), [1,2,3], [2,5,-2])
+julia> deriv.(L2DistLoss(), [2,5,-2], [1,2,3])
 3-element Vector{Int64}:
    2
    6
@@ -190,7 +190,7 @@ julia> deriv.(L2DistLoss(), [1,2,3], [2,5,-2])
 
 julia> buffer = zeros(3); # preallocate a buffer
 
-julia> buffer .= deriv.(L2DistLoss(), [1.,2,3], [2,5,-2])
+julia> buffer .= deriv.(L2DistLoss(), [2,5,-2], [1.,2,3])
 3-element Vector{Float64}:
    2.0
    6.0
@@ -202,7 +202,7 @@ Julia 0.6, one can also easily weight the influence of each
 observation without allocating a temporary array.
 
 ```jldoctest bcast2
-julia> buffer .= deriv.(L2DistLoss(), [1.,2,3], [2,5,-2]) .* [2,1,0.5]
+julia> buffer .= deriv.(L2DistLoss(), [2,5,-2], [1.,2,3]) .* [2,1,0.5]
 3-element Vector{Float64}:
   4.0
   6.0
@@ -226,7 +226,7 @@ it. Thus, one can make use of preallocated memory for storing the
 element-wise derivatives.
 
 ```jldoctest
-julia> deriv2.(LogitDistLoss(), [-0.5, 1.2, 3], [0.3, 2.3, -2])
+julia> deriv2.(LogitDistLoss(), [0.3, 2.3, -2], [-0.5, 1.2, 3])
 3-element Vector{Float64}:
  0.42781939304058886
  0.3747397590950413
@@ -234,7 +234,7 @@ julia> deriv2.(LogitDistLoss(), [-0.5, 1.2, 3], [0.3, 2.3, -2])
 
 julia> buffer = zeros(3); # preallocate a buffer
 
-julia> buffer .= deriv2.(LogitDistLoss(), [-0.5, 1.2, 3], [0.3, 2.3, -2])
+julia> buffer .= deriv2.(LogitDistLoss(), [0.3, 2.3, -2], [-0.5, 1.2, 3])
 3-element Vector{Float64}:
  0.42781939304058886
  0.3747397590950413

--- a/src/supervised/distance.jl
+++ b/src/supervised/distance.jl
@@ -507,7 +507,6 @@ L(r) = log ( cosh ( x ))
                  ŷ - y                            ŷ - y
 ```
 """
-
 struct LogCoshLoss <: DistanceLoss end
 
 _softplus(x::T) where T<:Number = x > zero(T) ? x + log1p(exp(-x)) : log1p(exp(x))

--- a/src/supervised/other.jl
+++ b/src/supervised/other.jl
@@ -20,9 +20,9 @@ value(::MisclassLoss{R}, agreement::Bool) where R = ifelse(agreement, zero(R), o
 deriv(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 deriv2(::MisclassLoss{R}, agreement::Bool) where R = zero(R)
 
-value(loss::MisclassLoss, target::NumberOrValue, output::NumberOrValue) = value(loss, target == output)
-deriv(loss::MisclassLoss, target::NumberOrValue, output::NumberOrValue) = deriv(loss, target == output)
-deriv2(loss::MisclassLoss, target::NumberOrValue, output::NumberOrValue) = deriv2(loss, target == output)
+value(loss::MisclassLoss, output::NumberOrValue, target::NumberOrValue) = value(loss, target == output)
+deriv(loss::MisclassLoss, output::NumberOrValue, target::NumberOrValue) = deriv(loss, target == output)
+deriv2(loss::MisclassLoss, output::NumberOrValue, target::NumberOrValue) = deriv2(loss, target == output)
 
 isminimizable(::MisclassLoss) = false
 isdifferentiable(::MisclassLoss) = false
@@ -42,13 +42,13 @@ isclipable(::MisclassLoss) = false
 
 Loss under a Poisson noise distribution (KL-divergence)
 
-``L(target, output) = exp(output) - target*output``
+``L(output, target) = exp(output) - target*output``
 """
 struct PoissonLoss <: SupervisedLoss end
 
-value(loss::PoissonLoss, target::Number, output::Number) = exp(output) - target*output
-deriv(loss::PoissonLoss, target::Number, output::Number) = exp(output) - target
-deriv2(loss::PoissonLoss, target::Number, output::Number) = exp(output)
+value(loss::PoissonLoss, output::Number, target::Number) = exp(output) - target*output
+deriv(loss::PoissonLoss, output::Number, target::Number) = exp(output) - target
+deriv2(loss::PoissonLoss, output::Number, target::Number) = exp(output)
 
 isdifferentiable(::PoissonLoss) = true
 isdifferentiable(::PoissonLoss, y, t) = true
@@ -64,13 +64,13 @@ isstronglyconvex(::PoissonLoss) = false
 @doc doc"""
     CrossEntropyLoss <: SupervisedLoss
 
-Cross-entropy loss also known as log loss and logistic loss is defined as:
+The cross-entropy loss is defined as:
 
-``L(target, output) = - target*ln(output) - (1-target)*ln(1-output)``
+``L(output, target) = - target*log(output) - (1-target)*log(1-output)``
 """
 struct CrossEntropyLoss <: SupervisedLoss end
 
-function value(loss::CrossEntropyLoss, target::Number, output::Number)
+function value(loss::CrossEntropyLoss, output::Number, target::Number)
     target >= 0 && target <=1 || error("target must be in [0,1]")
     output >= 0 && output <=1 || error("output must be in [0,1]")
     if target == 0
@@ -81,8 +81,8 @@ function value(loss::CrossEntropyLoss, target::Number, output::Number)
         -(target * log(output) + (1-target) * log(1-output))
     end
 end
-deriv(loss::CrossEntropyLoss, target::Number, output::Number) = (1-target) / (1-output) - target / output
-deriv2(loss::CrossEntropyLoss, target::Number, output::Number) = (1-target) / (1-output)^2 + target / output^2
+deriv(loss::CrossEntropyLoss, output::Number, target::Number) = (1-target) / (1-output) - target / output
+deriv2(loss::CrossEntropyLoss, output::Number, target::Number) = (1-target) / (1-output)^2 + target / output^2
 
 isdifferentiable(::CrossEntropyLoss) = true
 isdifferentiable(::CrossEntropyLoss, y, t) = t != 0 && t != 1

--- a/src/supervised/scaled.jl
+++ b/src/supervised/scaled.jl
@@ -18,19 +18,24 @@ ScaledLoss(loss::T, k::Number) where {T} = ScaledLoss(loss, Val(k))
 
 @generated ScaledLoss(s::ScaledLoss{T,K1}, ::Val{K2}) where {T,K1,K2} = :(ScaledLoss(s.loss, Val($(K1*K2))))
 
-for fun in (:value, :deriv, :deriv2)
-    @eval @fastmath ($fun)(l::ScaledLoss{T,K}, target::Number, output::Number) where {T,K} = K * ($fun)(l.loss, target, output)
+for FUN in (:value, :deriv, :deriv2)
+    @eval @fastmath function ($FUN)(
+        l::ScaledLoss{T,K},
+        output::Number,
+        target::Number) where {T,K}
+        K * ($FUN)(l.loss, output, target)
+    end
 end
 
-for prop in [:isminimizable, :isdifferentiable, :istwicedifferentiable,
+for FUN in [:isminimizable, :isdifferentiable, :istwicedifferentiable,
              :isconvex, :isstrictlyconvex, :isstronglyconvex,
              :isnemitski, :isunivfishercons, :isfishercons,
              :islipschitzcont, :islocallylipschitzcont,
              :isclipable, :ismarginbased, :isclasscalibrated,
              :isdistancebased, :issymmetric]
-    @eval ($prop)(l::ScaledLoss) = ($prop)(l.loss)
+    @eval ($FUN)(l::ScaledLoss) = ($FUN)(l.loss)
 end
 
-for prop_param in (:isdifferentiable, :istwicedifferentiable)
-    @eval ($prop_param)(l::ScaledLoss, at) = ($prop_param)(l.loss, at)
+for FUN in (:isdifferentiable, :istwicedifferentiable)
+    @eval ($FUN)(l::ScaledLoss, at) = ($FUN)(l.loss, at)
 end

--- a/src/supervised/weighted.jl
+++ b/src/supervised/weighted.jl
@@ -29,13 +29,13 @@ function WeightedMarginLoss(s::WeightedMarginLoss{L,W}, w::Number) where {L<:Mar
     WeightedMarginLoss(s.loss, Val(W*w))
 end
 
-for fun in (:value, :deriv, :deriv2)
-    @eval function ($fun)(l::WeightedMarginLoss{L,W}, target::Number, output::Number) where {L,W}
+for FUN in (:value, :deriv, :deriv2)
+    @eval function ($FUN)(l::WeightedMarginLoss{L,W}, output::Number, target::Number) where {L,W}
         # We interpret the W to be the weight of the positive class
         if target > 0
-            W * ($fun)(l.loss, target, output)
+            W * ($FUN)(l.loss, output, target)
         else
-            (1-W) * ($fun)(l.loss, target, output)
+            (1-W) * ($FUN)(l.loss, output, target)
         end
     end
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -33,37 +33,23 @@ for the simplification `L(x, ŷ)`.
 abstract type UnsupervisedLoss <: Loss end
 
 """
-    value(loss, target, output) -> Number
+    value(loss, output, target) -> Number
 
 Compute the (non-negative) numeric result for the `loss` function.
 Note that `target` and `output` can be of different numeric type,
 in which case promotion is performed in the manner appropriate for
 the given loss.
 
-    value(loss, targets, outputs) -> AbstractVector
+    value(loss, outputs, targets) -> AbstractVector
 
 Compute the result for each pair of values in `targets` and `outputs`.
 
-    value(loss, targets, outputs, aggmode) -> Number
+    value(loss, outputs, targets, aggmode) -> Number
 
 Compute the weighted or unweighted sum or mean (depending on
 aggregation mode `aggmode`) of the individual values of the `loss`
 function for each pair in `targets` and `outputs`. This method
 will not allocate a temporary array.
-
-In the case that the two parameters are arrays with a different
-number of dimensions, broadcast will be performed. Note that the
-given parameters are expected to have the same size in the
-dimensions they share.
-
-    value(loss, targets, outputs, aggmode, obsdim) -> AbstractVector
-
-Compute the aggregated result along dimension with observations `obsdim`.
-This method will not allocate a temporary array, but it will allocate
-the resulting vector.
-
-Both arrays have to be of the same shape and size. Furthermore they have
-to have at least two dimensions (i.e. they must not be vectors).
 
 ## Notes
 
@@ -74,37 +60,23 @@ to have at least two dimensions (i.e. they must not be vectors).
 function value end
 
 """
-    deriv(loss, target, output) -> Number
+    deriv(loss, output, target) -> Number
 
 Compute the analytical derivative with respect to the `output` for the
 `loss` function. Note that `target` and `output` can be of different
 numeric type, in which case promotion is performed in the manner
 appropriate for the given loss.
 
-    deriv(loss, targets, outputs) -> AbstractVector
+    deriv(loss, outputs, targets) -> AbstractVector
 
 Compute the result for each pair of values in `targets` and `outputs`.
 
-    deriv(loss, targets, outputs, aggmode) -> Number
+    deriv(loss, outputs, targets, aggmode) -> Number
 
 Compute the weighted or unweighted sum or mean (depending on
 aggregation mode `aggmode`) of the individual values of the `loss`
 function for each pair in `targets` and `outputs`. This method
 will not allocate a temporary array.
-
-In the case that the two parameters are arrays with a different
-number of dimensions, broadcast will be performed. Note that the
-given parameters are expected to have the same size in the
-dimensions they share.
-
-    deriv(loss, targets, outputs, aggmode, obsdim) -> AbstractVector
-
-Compute the aggregated result along dimension with observations `obsdim`.
-This method will not allocate a temporary array, but it will allocate
-the resulting vector.
-
-Both arrays have to be of the same shape and size. Furthermore they have
-to have at least two dimensions (i.e. they must not be vectors).
 
 ## Notes
 
@@ -115,37 +87,23 @@ to have at least two dimensions (i.e. they must not be vectors).
 function deriv end
 
 """
-    deriv2(loss, target, output) -> Number
+    deriv2(loss, output, target) -> Number
 
 Compute the second derivative with respect to the `output` for the
 `loss` function. Note that `target` and `output` can be of different
 numeric type, in which case promotion is performed in the manner
 appropriate for the given loss.
 
-    deriv2(loss, targets, outputs) -> AbstractVector
+    deriv2(loss, outputs, targets) -> AbstractVector
 
 Compute the result for each pair of values in `targets` and `outputs`.
 
-    deriv2(loss, targets, outputs, aggmode) -> Number
+    deriv2(loss, outputs, targets, aggmode) -> Number
 
 Compute the weighted or unweighted sum or mean (depending on
 aggregation mode `aggmode`) of the individual values of the `loss`
 function for each pair in `targets` and `outputs`. This method
 will not allocate a temporary array.
-
-In the case that the two parameters are arrays with a different
-number of dimensions, broadcast will be performed. Note that the
-given parameters are expected to have the same size in the
-dimensions they share.
-
-    deriv2(loss, targets, outputs, aggmode, obsdim) -> AbstractVector
-
-Compute the aggregated result along dimension with observations `obsdim`.
-This method will not allocate a temporary array, but it will allocate
-the resulting vector.
-
-Both arrays have to be of the same shape and size. Furthermore they have
-to have at least two dimensions (i.e. they must not be vectors).
 
 ## Notes
 

--- a/test/tst_api.jl
+++ b/test/tst_api.jl
@@ -1,33 +1,33 @@
-function test_vector_value(l, t, y)
-    ref = [value(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(value(l, t, y, AggMode.None())) == ref
-    @test @inferred(value(l, t, y)) == ref
-    @test value.(l, t, y) == ref
-    @test @inferred(l(t, y)) == ref
+function test_vector_value(l, o, t)
+    ref = [value(l, o[i], t[i]) for i in 1:length(o)]
+    @test @inferred(value(l, o, t, AggMode.None())) == ref
+    @test @inferred(value(l, o, t)) == ref
+    @test value.(l, o, t) == ref
+    @test @inferred(l(o, t)) == ref
     n = length(ref)
     s = sum(ref)
-    @test @inferred(value(l, t, y, AggMode.Sum())) ≈ s
-    @test @inferred(value(l, t, y, AggMode.Mean())) ≈ s / n
+    @test @inferred(value(l, o, t, AggMode.Sum())) ≈ s
+    @test @inferred(value(l, o, t, AggMode.Mean())) ≈ s / n
     ## Weighted Sum
-    @test @inferred(value(l, t, y, AggMode.WeightedSum(ones(n)))) ≈ s
-    @test @inferred(value(l, t, y, AggMode.WeightedSum(ones(n),normalize=true))) ≈ s / n
+    @test @inferred(value(l, o, t, AggMode.WeightedSum(ones(n)))) ≈ s
+    @test @inferred(value(l, o, t, AggMode.WeightedSum(ones(n),normalize=true))) ≈ s / n
     ## Weighted Mean
-    @test @inferred(value(l, t, y, AggMode.WeightedMean(ones(n)))) ≈ (s / n) / n
-    @test @inferred(value(l, t, y, AggMode.WeightedMean(ones(n),normalize=false))) ≈ s / n
+    @test @inferred(value(l, o, t, AggMode.WeightedMean(ones(n)))) ≈ (s / n) / n
+    @test @inferred(value(l, o, t, AggMode.WeightedMean(ones(n),normalize=false))) ≈ s / n
 end
 
-function test_vector_deriv(l, t, y)
-    ref = [deriv(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(deriv(l, t, y, AggMode.None())) == ref
-    @test @inferred(deriv(l, t, y)) == ref
-    @test deriv.(Ref(l), t, y) == ref
+function test_vector_deriv(l, o, t)
+    ref = [deriv(l, o[i], t[i]) for i in 1:length(o)]
+    @test @inferred(deriv(l, o, t, AggMode.None())) == ref
+    @test @inferred(deriv(l, o, t)) == ref
+    @test deriv.(Ref(l), o, t) == ref
 end
 
-function test_vector_deriv2(l, t, y)
-    ref = [deriv2(l,t[i],y[i]) for i in CartesianIndices(size(y))]
-    @test @inferred(deriv2(l, t, y, AggMode.None())) == ref
-    @test @inferred(deriv2(l, t, y)) == ref
-    @test deriv2.(Ref(l), t, y) == ref
+function test_vector_deriv2(l, o, t)
+    ref = [deriv2(l, o[i], t[i]) for i in 1:length(o)]
+    @test @inferred(deriv2(l, o, t, AggMode.None())) == ref
+    @test @inferred(deriv2(l, o, t)) == ref
+    @test deriv2.(Ref(l), o, t) == ref
 end
 
 @testset "Vectorized API" begin
@@ -40,9 +40,9 @@ end
                     for loss in (LogitMarginLoss(),ModifiedHuberLoss(),
                                  L1HingeLoss(),SigmoidLoss())
                         @testset "$(loss): " begin
-                            test_vector_value(loss, targets, outputs)
-                            test_vector_deriv(loss, targets, outputs)
-                            test_vector_deriv2(loss, targets, outputs)
+                            test_vector_value(loss, outputs, targets)
+                            test_vector_deriv(loss, outputs, targets)
+                            test_vector_deriv2(loss, outputs, targets)
                         end
                     end
                 end
@@ -55,9 +55,9 @@ end
                     for loss in (QuantileLoss(0.75),L2DistLoss(),
                                  EpsilonInsLoss(1))
                         @testset "$(loss): " begin
-                            test_vector_value(loss, targets, outputs)
-                            test_vector_deriv(loss, targets, outputs)
-                            test_vector_deriv2(loss, targets, outputs)
+                            test_vector_value(loss, outputs, targets)
+                            test_vector_deriv(loss, outputs, targets)
+                            test_vector_deriv2(loss, outputs, targets)
                         end
                     end
                 end

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -1,20 +1,20 @@
 function test_value_typestable(l::SupervisedLoss)
     @testset "$(l): " begin
-        for y in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
+        for o in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
             for t in (-2, 2, Int32(-1), Int32(1), -.5, .5, Float32(-1), Float32(1))
                 # check inference
-                @inferred deriv(l, y, t)
-                @inferred deriv2(l, y, t)
+                @inferred deriv(l, o, t)
+                @inferred deriv2(l, o, t)
 
                 # get expected return type
-                T = promote_type(typeof(y), typeof(t))
+                T = promote_type(typeof(o), typeof(t))
 
                 # test basic loss
-                val = @inferred value(l, y, t)
+                val = @inferred value(l, o, t)
                 @test typeof(val) <: T
 
                 # test scaled version of loss
-                @test typeof(value(T(2)*l, y, t)) <: T
+                @test typeof(value(T(2)*l, o, t)) <: T
             end
         end
     end
@@ -22,14 +22,14 @@ end
 
 function test_value_float32_preserving(l::SupervisedLoss)
     @testset "$(l): " begin
-        for y in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
+        for o in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
             for t in (-2, 2, Int32(-1), Int32(1), -.5, .5, Float32(-1), Float32(1))
                 # check inference
-                @inferred deriv(l, y, t)
-                @inferred deriv2(l, y, t)
+                @inferred deriv(l, o, t)
+                @inferred deriv2(l, o, t)
 
-                val = @inferred value(l, y, t)
-                T = promote_type(typeof(y),typeof(t))
+                val = @inferred value(l, o, t)
+                T = promote_type(typeof(o),typeof(t))
                 if !(T <: AbstractFloat)
                     # cast Integers to a float
                     # (whether its Float32 or Float64 depends on the loss...)
@@ -47,119 +47,116 @@ end
 
 function test_value_float64_forcing(l::SupervisedLoss)
     @testset "$(l): " begin
-        for y in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
+        for o in (-1, 1, Int32(-1), Int32(1), -1.5, 1.5, Float32(-.5), Float32(.5))
             for t in (-2, 2, Int32(-1), Int32(1), -.5, .5, Float32(-1), Float32(1))
                 # check inference
-                @inferred deriv(l, y, t)
-                @inferred deriv2(l, y, t)
+                @inferred deriv(l, o, t)
+                @inferred deriv2(l, o, t)
 
-                val = @inferred value(l, y, t)
+                val = @inferred value(l, o, t)
                 @test (typeof(val) <: Float64)
             end
         end
     end
 end
 
-function test_value(l::SupervisedLoss, f::Function, y_vec, t_vec)
+function test_value(l::SupervisedLoss, f::Function, o_vec, t_vec)
     @testset "$(l): " begin
-        for y in y_vec, t in t_vec
-            @test abs(value(l, y, t) - f(y, t)) < 1e-10
+        for o in o_vec, t in t_vec
+            @test abs(value(l, o, t) - f(o, t)) < 1e-10
         end
     end
 end
 
-function test_deriv(l::MarginLoss, t_vec)
+function test_deriv(l::MarginLoss, o_vec)
     @testset "$(l): " begin
-        for y in [-1., 1], t in t_vec
-            if isdifferentiable(l, y*t)
-                d_dual = epsilon(value(l, dual(y, zero(y)), dual(t, one(t))))
-                d_comp = @inferred deriv(l, y, t)
+        for o in o_vec, t in [-1., 1.]
+            if isdifferentiable(l, o*t)
+                d_dual = epsilon(value(l, dual(o, one(o)), dual(t, zero(t))))
+                d_comp = @inferred deriv(l, o, t)
                 @test abs(d_dual - d_comp) < 1e-10
-                val = @inferred value(l, y, t)
-                @test val ≈ value(l, y, t)
-                @test val ≈ value(l, y*t)
-                @test d_comp ≈ y*deriv(l, y*t)
-            else
-                # y*t == 1 ? print(".") : print("(no $(y)*$(t)) ")
-                #print(".")
+                val = @inferred value(l, o, t)
+                @test val ≈ value(l, o, t)
+                @test val ≈ value(l, o*t)
+                @test d_comp ≈ t*deriv(l, o*t)
             end
         end
     end
 end
 
-function test_deriv(l::DistanceLoss, t_vec)
+function test_deriv(l::DistanceLoss, o_vec)
     @testset "$(l): " begin
-        for y in -10:.2:10, t in t_vec
-            if isdifferentiable(l, t-y)
-                d_dual = epsilon(value(l, dual(t-y, one(t-y))))
-                d_comp = @inferred deriv(l, y, t)
+        for o in o_vec, t in -10:.2:10
+            if isdifferentiable(l, o-t)
+                d_dual = epsilon(value(l, dual(o-t, one(o-t))))
+                d_comp = @inferred deriv(l, o, t)
                 @test abs(d_dual - d_comp) < 1e-10
-                val = @inferred value(l, y, t)
-                @test val ≈ value(l, y, t)
-                @test val ≈ value(l, t-y)
-                @test d_comp ≈ deriv(l, t-y)
+                val = @inferred value(l, o, t)
+                @test val ≈ value(l, o, t)
+                @test val ≈ value(l, o-t)
+                @test d_comp ≈ deriv(l, o-t)
             end
         end
     end
 end
 
-function test_deriv(l::SupervisedLoss, y_vec, t_vec)
+function test_deriv(l::SupervisedLoss, o_vec, t_vec)
     @testset "$(l): " begin
-        for y in y_vec, t in t_vec
-            if isdifferentiable(l, y, t)
-                d_dual = epsilon(value(l, y, dual(t, one(t))))
-                d_comp = @inferred deriv(l, y, t)
+        for o in o_vec, t in t_vec
+            if isdifferentiable(l, o, t)
+                d_dual = epsilon(value(l, dual(o, one(o)), dual(t, zero(t))))
+                d_comp = @inferred deriv(l, o, t)
                 @test abs(d_dual - d_comp) < 1e-10
-                val = @inferred value(l, y, t)
-                @test val ≈ value(l, y, t)
-                @test d_comp ≈ deriv(l, y, t)
+                val = @inferred value(l, o, t)
+                @test val ≈ value(l, o, t)
+                @test d_comp ≈ deriv(l, o, t)
             end
         end
     end
 end
 
-function test_deriv2(l::MarginLoss, t_vec)
+function test_deriv2(l::MarginLoss, o_vec)
     @testset "$(l): " begin
-        for y in [-1., 1], t in t_vec
-            if istwicedifferentiable(l, y*t) && isdifferentiable(l, y*t)
-                d2_dual = epsilon(deriv(l, dual(y, zero(y)), dual(t, one(t))))
-                d2_comp = @inferred deriv2(l, y, t)
+        for o in o_vec, t in [-1., 1]
+            if istwicedifferentiable(l, o*t) && isdifferentiable(l, o*t)
+                d2_dual = epsilon(deriv(l, dual(o, one(o)), dual(t, zero(t))))
+                d2_comp = @inferred deriv2(l, o, t)
                 @test abs(d2_dual - d2_comp) < 1e-10
-                @test d2_comp ≈ @inferred deriv2(l, y, t)
-                @test d2_comp ≈ @inferred deriv2(l, y*t)
+                @test d2_comp ≈ @inferred deriv2(l, o, t)
+                @test d2_comp ≈ @inferred deriv2(l, o*t)
             end
         end
     end
 end
 
-function test_deriv2(l::DistanceLoss, t_vec)
+function test_deriv2(l::DistanceLoss, o_vec)
     @testset "$(l): " begin
-        for y in -10:.2:10, t in t_vec
-            if istwicedifferentiable(l, t-y) && isdifferentiable(l, t-y)
-                d2_dual = epsilon(deriv(l, dual(t-y, one(t-y))))
-                d2_comp = @inferred deriv2(l, y, t)
+        for o in o_vec, t in -10:.2:10
+            if istwicedifferentiable(l, o-t) && isdifferentiable(l, o-t)
+                d2_dual = epsilon(deriv(l, dual(o-t, one(o-t))))
+                d2_comp = @inferred deriv2(l, o, t)
                 @test abs(d2_dual - d2_comp) < 1e-10
-                @test d2_comp ≈ @inferred deriv2(l, y, t)
-                @test d2_comp ≈ @inferred deriv2(l, t-y)
+                @test d2_comp ≈ @inferred deriv2(l, o, t)
+                @test d2_comp ≈ @inferred deriv2(l, o-t)
             end
         end
     end
 end
 
-function test_deriv2(l::SupervisedLoss, y_vec, t_vec)
+function test_deriv2(l::SupervisedLoss, o_vec, t_vec)
     @testset "$(l): " begin
-        for y in y_vec, t in t_vec
-            if istwicedifferentiable(l, y, t) && isdifferentiable(l, y, t)
-                d2_dual = epsilon(deriv(l, dual(y, zero(y)), dual(t, one(t))))
-                d2_comp = @inferred deriv2(l, y, t)
+        for o in o_vec, t in t_vec
+            if istwicedifferentiable(l, o, t) && isdifferentiable(l, o, t)
+                d2_dual = epsilon(deriv(l, dual(o, one(o)), dual(t, zero(t))))
+                d2_comp = @inferred deriv2(l, o, t)
                 @test abs(d2_dual - d2_comp) < 1e-10
-                @test d2_comp ≈ @inferred deriv2(l, y, t)
+                @test d2_comp ≈ @inferred deriv2(l, o, t)
             end
         end
     end
 end
 
-function test_scaledloss(l::SupervisedLoss, t_vec, y_vec)
+function test_scaledloss(l::SupervisedLoss, o_vec, t_vec)
     @testset "Scaling for $(l): " begin
         for λ = (2.0, 2)
             sl = ScaledLoss(l,λ)
@@ -169,12 +166,10 @@ function test_scaledloss(l::SupervisedLoss, t_vec, y_vec)
             @test sl == @inferred(ScaledLoss(l,Val(λ)))
             @test sl == λ * l
             @test sl == @inferred(Val(λ) * l)
-            for t in t_vec
-                for y in y_vec
-                    @test @inferred(value(sl,t,y)) == λ*value(l,t,y)
-                    @test @inferred(deriv(sl,t,y)) == λ*deriv(l,t,y)
-                    @test @inferred(deriv2(sl,t,y)) == λ*deriv2(l,t,y)
-                end
+            for o in o_vec, t in t_vec
+                @test @inferred(value(sl, o, t)) == λ * value(l, o, t)
+                @test @inferred(deriv(sl, o, t)) == λ * deriv(l, o, t)
+                @test @inferred(deriv2(sl, o, t)) == λ * deriv2(l, o, t)
             end
         end
     end
@@ -192,23 +187,21 @@ function test_scaledloss(l::SupervisedLoss, n_vec)
     end
 end
 
-function test_weightedloss(l::MarginLoss, t_vec, y_vec)
+function test_weightedloss(l::MarginLoss, o_vec, t_vec)
     @testset "Weighted version for $(l): " begin
         for w in (0., 0.2, 0.7, 1.)
             wl = WeightedMarginLoss(l, w)
             @test typeof(wl) <: WeightedMarginLoss{typeof(l),w}
             @test WeightedMarginLoss(l, w * 0.1) == WeightedMarginLoss(wl, 0.1)
-            for t in t_vec
-                for y in y_vec
-                    if t == 1
-                        @test value(wl,t,y) == w*value(l,t,y)
-                        @test deriv(wl,t,y) == w*deriv(l,t,y)
-                        @test deriv2(wl,t,y) == w*deriv2(l,t,y)
-                    else
-                        @test value(wl,t,y) == (1-w)*value(l,t,y)
-                        @test deriv(wl,t,y) == (1-w)*deriv(l,t,y)
-                        @test deriv2(wl,t,y) == (1-w)*deriv2(l,t,y)
-                    end
+            for o in o_vec, t in t_vec
+                if t == 1
+                    @test value(wl, o, t) == w * value(l, o, t)
+                    @test deriv(wl, o, t) == w * deriv(l, o, t)
+                    @test deriv2(wl, o, t) == w * deriv2(l, o, t)
+                else
+                    @test value(wl, o, t) == (1-w) * value(l, o, t)
+                    @test deriv(wl, o, t) == (1-w) * deriv(l, o, t)
+                    @test deriv2(wl, o, t) == (1-w) * deriv2(l, o, t)
                 end
             end
         end
@@ -261,221 +254,188 @@ end
     end
 end
 
-println("<HEARTBEAT>")
-
 @testset "Test margin-based loss against reference function" begin
-    _zerooneloss(y, t) = sign(y*t) < 0 ? 1 : 0
-    test_value(ZeroOneLoss(), _zerooneloss, [-1.,1], -10:0.2:10)
+    _zerooneloss(o, t) = sign(o*t) < 0 ? 1 : 0
+    test_value(ZeroOneLoss(), _zerooneloss, -10:0.2:10, [-1.,1.])
 
-    _hingeloss(y, t) = max(0, 1 - y.*t)
-    test_value(HingeLoss(), _hingeloss, [-1.,1], -10:0.2:10)
+    _hingeloss(o, t) = max(0, 1 - o.*t)
+    test_value(HingeLoss(), _hingeloss, -10:0.2:10, [-1.,1.])
 
-    _l2hingeloss(y, t) = max(0, 1 - y.*t)^2
-    test_value(L2HingeLoss(), _l2hingeloss, [-1.,1], -10:0.2:10)
+    _l2hingeloss(o, t) = max(0, 1 - o.*t)^2
+    test_value(L2HingeLoss(), _l2hingeloss, -10:0.2:10, [-1.,1.])
 
-    _perceptronloss(y, t) = max(0, -y.*t)
-    test_value(PerceptronLoss(), _perceptronloss, [-1.,1], -10:0.2:10)
+    _perceptronloss(o, t) = max(0, -o.*t)
+    test_value(PerceptronLoss(), _perceptronloss, -10:0.2:10, [-1.,1.])
 
-    _logitmarginloss(y, t) = log(1 + exp(-y.*t))
-    test_value(LogitMarginLoss(), _logitmarginloss, [-1.,1], -10:0.2:10)
+    _logitmarginloss(o, t) = log(1 + exp(-o.*t))
+    test_value(LogitMarginLoss(), _logitmarginloss, -10:0.2:10, [-1.,1.])
 
     function _smoothedl1hingeloss(γ)
-        function _value(y, t)
-            if y.*t >= 1 - γ
-                1/(2γ) * max(0, 1- y.*t)^2
+        function _value(o, t)
+            if o.*t >= 1 - γ
+                1/(2γ) * max(0, 1- o.*t)^2
             else
-                1 - γ / 2 - y.*t
+                1 - γ / 2 - o.*t
             end
         end
         _value
     end
-    test_value(SmoothedL1HingeLoss(.5), _smoothedl1hingeloss(.5), [-1.,1], -10:0.2:10)
-    test_value(SmoothedL1HingeLoss(1), _smoothedl1hingeloss(1), [-1.,1], -10:0.2:10)
-    test_value(SmoothedL1HingeLoss(2), _smoothedl1hingeloss(2), [-1.,1], -10:0.2:10)
+    test_value(SmoothedL1HingeLoss(.5), _smoothedl1hingeloss(.5), -10:0.2:10, [-1.,1.])
+    test_value(SmoothedL1HingeLoss(1), _smoothedl1hingeloss(1), -10:0.2:10, [-1.,1.])
+    test_value(SmoothedL1HingeLoss(2), _smoothedl1hingeloss(2), -10:0.2:10, [-1.,1.])
 
-    function _modhuberloss(y, t)
-        if y .* t >= -1
-            max(0, 1 - y .* t)^2
+    function _modhuberloss(o, t)
+        if o .* t >= -1
+            max(0, 1 - o .* t)^2
         else
-            -4 .* y .* t
+            -4 .* o .* t
         end
     end
-    test_value(ModifiedHuberLoss(), _modhuberloss, [-1.,1], -10:0.2:10)
+    test_value(ModifiedHuberLoss(), _modhuberloss, -10:0.2:10, [-1.,1.])
 
-    _l2marginloss(y, t) = (1 - y.*t)^2
-    test_value(L2MarginLoss(), _l2marginloss, [-1.,1], -10:0.2:10)
+    _l2marginloss(o, t) = (1 - o.*t)^2
+    test_value(L2MarginLoss(), _l2marginloss, -10:0.2:10, [-1.,1.])
 
-    _exploss(y, t) = exp(-y.*t)
-    test_value(ExpLoss(), _exploss, [-1.,1], -10:0.2:10)
+    _exploss(o, t) = exp(-o.*t)
+    test_value(ExpLoss(), _exploss, -10:0.2:10, [-1.,1.])
 
-    _sigmoidloss(y, t) = (1-tanh(y.*t))
-    test_value(SigmoidLoss(), _sigmoidloss, [-1., 1], -10:0.2:10)
+    _sigmoidloss(o, t) = (1-tanh(o.*t))
+    test_value(SigmoidLoss(), _sigmoidloss, -10:0.2:10, [-1.,1.])
 
     function _dwdmarginloss(q)
-        function _value(y, t)
-            if y.*t <= q/(q+1)
-                convert(Float64, 1 - y.*t)
+        function _value(o, t)
+            if o.*t <= q/(q+1)
+                convert(Float64, 1 - o.*t)
             else
-                ((q^q)/(q+1)^(q+1)) / (y.*t)^q
+                ((q^q)/(q+1)^(q+1)) / (o.*t)^q
             end
         end
         _value
     end
-    test_value(DWDMarginLoss(0.5), _dwdmarginloss(0.5), [-1., 1], -10:0.2:10)
-    test_value(DWDMarginLoss(1), _dwdmarginloss(1), [-1., 1], -10:0.2:10)
-    test_value(DWDMarginLoss(2), _dwdmarginloss(2), [-1., 1], -10:0.2:10)
-
+    test_value(DWDMarginLoss(0.5), _dwdmarginloss(0.5), -10:0.2:10, [-1.,1.])
+    test_value(DWDMarginLoss(1), _dwdmarginloss(1), -10:0.2:10, [-1.,1.])
+    test_value(DWDMarginLoss(2), _dwdmarginloss(2), -10:0.2:10, [-1.,1.])
 end
 
 @testset "Test distance-based loss against reference function" begin
-    yr, tr = range(-10, stop=20, length=10), range(-30, stop=30, length=10)
+    or = range(-10, stop=20, length=10)
+    tr = range(-30, stop=30, length=10)
 
-    _l1distloss(y, t) = abs(t - y)
-    test_value(L1DistLoss(), _l1distloss, yr, tr)
+    _l1distloss(o, t) = abs(t - o)
+    test_value(L1DistLoss(), _l1distloss, or, tr)
 
-    _l2distloss(y, t) = (t - y)^2
-    test_value(L2DistLoss(), _l2distloss, yr, tr)
+    _l2distloss(o, t) = (t - o)^2
+    test_value(L2DistLoss(), _l2distloss, or, tr)
 
-    _lp15distloss(y, t) = abs(t - y)^(1.5)
-    test_value(LPDistLoss(1.5), _lp15distloss, yr, tr)
+    _lp15distloss(o, t) = abs(t - o)^(1.5)
+    test_value(LPDistLoss(1.5), _lp15distloss, or, tr)
 
     function _periodicloss(c)
-        _value(y, t) = 1 - cos((y-t)*2π/c)
-        _value
+        (o, t) -> 1 - cos((o-t)*2π/c)
     end
-    test_value(PeriodicLoss(0.5), _periodicloss(0.5), yr, tr)
-    test_value(PeriodicLoss(1), _periodicloss(1), yr, tr)
-    test_value(PeriodicLoss(1.5), _periodicloss(1.5), yr, tr)
+    test_value(PeriodicLoss(0.5), _periodicloss(0.5), or, tr)
+    test_value(PeriodicLoss(1), _periodicloss(1), or, tr)
+    test_value(PeriodicLoss(1.5), _periodicloss(1.5), or, tr)
 
     function _huberloss(d)
-        _value(y, t) = abs(y-t)<d ? (abs2(y-t)/2) : (d*(abs(y-t) - (d/2)))
-        _value
+        (o, t) -> abs(o-t)<d ? (abs2(o-t)/2) : (d*(abs(o-t) - (d/2)))
     end
-    test_value(HuberLoss(0.5), _huberloss(0.5), yr, tr)
-    test_value(HuberLoss(1), _huberloss(1), yr, tr)
-    test_value(HuberLoss(1.5), _huberloss(1.5), yr, tr)
+    test_value(HuberLoss(0.5), _huberloss(0.5), or, tr)
+    test_value(HuberLoss(1), _huberloss(1), or, tr)
+    test_value(HuberLoss(1.5), _huberloss(1.5), or, tr)
 
     function _l1epsinsloss(ɛ)
-        _value(y, t) = max(0, abs(t - y) - ɛ)
-        _value
+        (o, t) -> max(0, abs(t - o) - ɛ)
     end
-    test_value(EpsilonInsLoss(0.5), _l1epsinsloss(0.5), yr, tr)
-    test_value(EpsilonInsLoss(1), _l1epsinsloss(1), yr, tr)
-    test_value(EpsilonInsLoss(1.5), _l1epsinsloss(1.5), yr, tr)
+    test_value(EpsilonInsLoss(0.5), _l1epsinsloss(0.5), or, tr)
+    test_value(EpsilonInsLoss(1), _l1epsinsloss(1), or, tr)
+    test_value(EpsilonInsLoss(1.5), _l1epsinsloss(1.5), or, tr)
 
     function _l2epsinsloss(ɛ)
-        _value(y, t) = max(0, abs(t - y) - ɛ)^2
-        _value
+        (o, t) -> max(0, abs(t - o) - ɛ)^2
     end
-    test_value(L2EpsilonInsLoss(0.5), _l2epsinsloss(0.5), yr, tr)
-    test_value(L2EpsilonInsLoss(1), _l2epsinsloss(1), yr, tr)
-    test_value(L2EpsilonInsLoss(1.5), _l2epsinsloss(1.5), yr, tr)
+    test_value(L2EpsilonInsLoss(0.5), _l2epsinsloss(0.5), or, tr)
+    test_value(L2EpsilonInsLoss(1), _l2epsinsloss(1), or, tr)
+    test_value(L2EpsilonInsLoss(1.5), _l2epsinsloss(1.5), or, tr)
 
-    _logitdistloss(y, t) = -log((4*exp(t-y))/(1+exp(t-y))^2)
-    test_value(LogitDistLoss(), _logitdistloss, yr, tr)
+    _logitdistloss(o, t) = -log((4*exp(t-o))/(1+exp(t-o))^2)
+    test_value(LogitDistLoss(), _logitdistloss, or, tr)
 
-    function _quantileloss(y, t)
-        (y - t) * (0.7 - (y - t < 0))
+    function _quantileloss(τ)
+        (o, t) -> (o - t) * ((o - t > 0) - τ)
     end
-    test_value(QuantileLoss(.7), _quantileloss, yr, tr)
+    test_value(QuantileLoss(.7), _quantileloss(.7), or, tr)
 
-    function _logcoshloss(y, t)
-        log.(cosh(y .- t))
+    function _logcoshloss(o, t)
+        log(cosh(o - t))
     end
-    test_value(LogCoshLoss(), _logcoshloss, yr, tr)
+    test_value(LogCoshLoss(), _logcoshloss, or, tr)
 end
 
-const OrdinalSmoothedHingeLoss = OrdinalMarginLoss{<:SmoothedL1HingeLoss}
-@test OrdinalSmoothedHingeLoss(4, 2.1) === OrdinalMarginLoss(SmoothedL1HingeLoss(2.1), 4)
+@testset "Test other loss" begin
+    _misclassloss(o, t) = o == t ? 0 : 1
+    test_value(MisclassLoss(), _misclassloss, vcat(1:5,7:11), 1:10)
 
-@testset "Test ordinal losses against reference function" begin
-    function _ordinalhingeloss(y, t)
-        val = 0
-        for yp = 1:y - 1
-            val += max(0, 1 - t + yp)
-        end
-        for yp = y + 1:5
-            val += max(0, 1 + t - yp)
-        end
-        val
+    _crossentropyloss(o, t) = -t*log(o) - (1-t)*log(1-o)
+    test_value(CrossEntropyLoss(), _crossentropyloss, 0.01:0.01:0.99, 0:0.01:1)
+
+    _poissonloss(o, t) = exp(o) - t*o
+    test_value(PoissonLoss(), _poissonloss, range(0,stop=10,length=11), 0:10)
+end
+
+@testset "Test scaled loss" begin
+    for loss in distance_losses
+        test_scaledloss(loss, -10:0.5:10, -10:.2:10)
+        test_scaledloss(loss, -10:0.5:10)
     end
-    y = rand(1:5, 10); t = randn(10) .+ 3
-    test_value(OrdinalMarginLoss(HingeLoss(), 5), _ordinalhingeloss, y, t)
-end
 
-
-@testset "Test other loss against reference function" begin
-    _misclassloss(y, t) = y == t ? 0 : 1
-    test_value(MisclassLoss(), _misclassloss, 1:10, vcat(1:5,7:11))
-
-    _crossentropyloss(y, t) = -y*log(t) - (1-y)*log(1-t)
-    test_value(CrossEntropyLoss(), _crossentropyloss, 0:0.01:1, 0.01:0.01:0.99)
-
-    _poissonloss(y, t) = exp(t) - t*y
-    test_value(PoissonLoss(), _poissonloss, 0:10, range(0,stop=10,length=11))
-    test_scaledloss(PoissonLoss(), 0:10, range(0,stop=10,length=11))
-end
-
-println("<HEARTBEAT>")
-
-# --------------------------------------------------------------
-
-@testset "Test first derivatives of margin-based losses" begin
     for loss in margin_losses
-        test_deriv(loss, -10:0.2:10)
-    end
-end
-
-@testset "Test second derivatives of margin-based losses" begin
-    for loss in margin_losses
-        test_deriv2(loss, -10:0.2:10)
-    end
-end
-
-@testset "Test margin-based scaled loss" begin
-    for loss in margin_losses
-        test_scaledloss(loss, [-1.,1], -10:0.2:10)
+        test_scaledloss(loss, -10:0.2:10, [-1.,1.])
         test_scaledloss(loss, -10:0.2:10)
     end
+
+    test_scaledloss(PoissonLoss(), range(0,stop=10,length=11), 0:10)
 end
 
-@testset "Test margin-based weighted loss" begin
+@testset "Test weighted loss" begin
     for loss in margin_losses
-        test_weightedloss(loss, [-1.,1], -10:0.2:10)
+        test_weightedloss(loss, -10:0.2:10, [-1.,1.])
     end
 end
 
 # --------------------------------------------------------------
 
-@testset "Test first derivatives of distance-based losses" begin
+@testset "Test first derivatives" begin
     for loss in distance_losses
         test_deriv(loss, -10:0.5:10)
     end
-end
 
-@testset "Test second derivatives of distance-based losses" begin
-    for loss in distance_losses
-        test_deriv2(loss, -10:0.5:10)
+    for loss in margin_losses
+        test_deriv(loss, -10:0.2:10)
     end
-end
 
-@testset "Test first and second derivatives of other losses" begin
     test_deriv(PoissonLoss(), -10:.2:10, 0:30)
-    test_deriv2(PoissonLoss(), -10:.2:10, 0:30)
-    test_deriv(CrossEntropyLoss(), 0:0.01:1, 0.01:0.01:0.99)
-    test_deriv2(CrossEntropyLoss(), 0:0.01:1, 0.01:0.01:0.99)
-end
-
-@testset "Test distance-based scaled loss" begin
-    for loss in distance_losses
-        test_scaledloss(loss, -10:.2:10, -10:0.5:10)
-        test_scaledloss(loss, -10:0.5:10)
-    end
+    #test_deriv(CrossEntropyLoss(), 0:0.01:1, 0.01:0.01:0.99)
 end
 
 # --------------------------------------------------------------
 
-@testset "Losses with categorical values" begin
+@testset "Test second derivatives" begin
+    for loss in distance_losses
+        test_deriv2(loss, -10:0.5:10)
+    end
+
+    for loss in margin_losses
+        test_deriv2(loss, -10:0.2:10)
+    end
+
+    test_deriv2(PoissonLoss(), -10:.2:10, 0:30)
+    #test_deriv2(CrossEntropyLoss(), 0:0.01:1, 0.01:0.01:0.99)
+end
+
+# --------------------------------------------------------------
+
+@testset "Test losses with categorical values" begin
     c = categorical(["Foo","Bar","Baz","Foo"])
 
     l = MisclassLoss()

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -415,7 +415,7 @@ end
     end
 
     test_deriv(PoissonLoss(), -10:.2:10, 0:30)
-    #test_deriv(CrossEntropyLoss(), 0:0.01:1, 0.01:0.01:0.99)
+    test_deriv(CrossEntropyLoss(), 0.01:0.01:0.99, 0:0.01:1)
 end
 
 # --------------------------------------------------------------
@@ -430,7 +430,7 @@ end
     end
 
     test_deriv2(PoissonLoss(), -10:.2:10, 0:30)
-    #test_deriv2(CrossEntropyLoss(), 0:0.01:1, 0.01:0.01:0.99)
+    test_deriv2(CrossEntropyLoss(), 0.01:0.01:0.99, 0:0.01:1)
 end
 
 # --------------------------------------------------------------
@@ -448,7 +448,7 @@ end
     @test value(l, c, reverse(c), AggMode.WeightedMean(2*ones(4),false)) == 1.0
     @test value(l, c, reverse(c), AggMode.WeightedMean(2*ones(4),true)) == 0.125
 
-    lf = MisclassLoss{Float32}()
-    @test value(lf, c[1], c[1]) isa Float32
-    @test value(lf, c, c) isa Vector{Float32}
+    l = MisclassLoss{Float32}()
+    @test value(l, c[1], c[1]) isa Float32
+    @test value(l, c, c) isa Vector{Float32}
 end

--- a/test/tst_loss.jl
+++ b/test/tst_loss.jl
@@ -175,18 +175,6 @@ function test_scaledloss(l::SupervisedLoss, o_vec, t_vec)
     end
 end
 
-function test_scaledloss(l::SupervisedLoss, n_vec)
-    @testset "Scaling for $(l): " begin
-        for λ = (2.0, 2)
-            sl = ScaledLoss(l,λ)
-            @test typeof(sl) <: ScaledLoss{typeof(l),λ}
-            @test sl == @inferred(ScaledLoss(l,Val(λ)))
-            @test sl == λ * l
-            @test sl == @inferred(Val(λ) * l)
-        end
-    end
-end
-
 function test_weightedloss(l::MarginLoss, o_vec, t_vec)
     @testset "Weighted version for $(l): " begin
         for w in (0., 0.2, 0.7, 1.)
@@ -386,12 +374,10 @@ end
 @testset "Test scaled loss" begin
     for loss in distance_losses
         test_scaledloss(loss, -10:0.5:10, -10:.2:10)
-        test_scaledloss(loss, -10:0.5:10)
     end
 
     for loss in margin_losses
         test_scaledloss(loss, -10:0.2:10, [-1.,1.])
-        test_scaledloss(loss, -10:0.2:10)
     end
 
     test_scaledloss(PoissonLoss(), range(0,stop=10,length=11), 0:10)


### PR DESCRIPTION
This PR reverts the order from (target, output) to (output, target), which matches with other ecosystems in Julia as discussed in #126.