### PR TITLE
Use `JuliaFormatter.jl` to format source code

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,10 @@
+indent = 2
+margin = 120
+always_for_in = true
+always_use_return = false
+whitespace_typedefs = false
+whitespace_in_kwargs = false
+whitespace_ops_in_indices = true
+remove_extra_newlines = true
+trailing_comma = false
+normalize_line_endings = "unix"

--- a/.github/workflows/FormatPR.yml
+++ b/.github/workflows/FormatPR.yml
@@ -1,0 +1,28 @@
+name: FormatPR
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install JuliaFormatter and format
+        run: |
+          julia -e 'import Pkg; Pkg.add("JuliaFormatter")'
+          julia -e 'using JuliaFormatter; format(".")'
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: ":robot: Format .jl files"
+          title: '[AUTO] JuliaFormatter.jl run'
+          branch: auto-juliaformatter-pr
+          delete-branch: true
+          labels: formatting, automated pr, no changelog
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
This PR also adds a GitHub Action that will format the source code when something is pushed to the master branch.