### PR TITLE
Move CategoricalArrays.jl into extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,19 @@
 name = "LossFunctions"
 uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
-CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[weakdeps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+
+[extensions]
+LossFunctionsCategoricalArraysExt = "CategoricalArrays"
 
 [compat]
 CategoricalArrays = "0.10"
+Requires = "1"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -17,3 +17,6 @@ LossFunctionsCategoricalArraysExt = "CategoricalArrays"
 CategoricalArrays = "0.10"
 Requires = "1"
 julia = "1.6"
+
+[extras]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/ext/LossFunctionsCategoricalArraysExt.jl
+++ b/ext/LossFunctionsCategoricalArraysExt.jl
@@ -1,0 +1,18 @@
+module LossFunctionsCategoricalArraysExt
+
+if isdefined(Base, :get_extension)
+    import LossFunctions: MisclassLoss, deriv, deriv2
+    import CategoricalArrays: CategoricalValue
+else
+    import ..LossFunctions: MisclassLoss, deriv, deriv2
+    import ..CategoricalArrays: CategoricalValue
+end
+
+# type alias to make code more readable
+const Scalar = Union{Number,CategoricalValue}
+
+(loss::MisclassLoss)(output::Scalar, target::Scalar) = loss(target == output)
+deriv(loss::MisclassLoss, output::Scalar, target::Scalar) = deriv(loss, target == output)
+deriv2(loss::MisclassLoss, output::Scalar, target::Scalar) = deriv2(loss, target == output)
+
+end

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -1,10 +1,10 @@
 module LossFunctions
 
 using Markdown
-using CategoricalArrays: CategoricalValue
 
 import Base: sum
 import Statistics: mean
+import Requires: @init, @require
 
 # trait functions
 include("traits.jl")
@@ -14,6 +14,11 @@ include("losses.jl")
 
 # IO methods
 include("io.jl")
+
+# Extensions
+if !isdefined(Base, :get_extension)
+  @init @require CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597" include("../ext/LossFunctionsCategoricalArraysExt.jl")
+end
 
 export
   # trait functions

--- a/src/losses.jl
+++ b/src/losses.jl
@@ -1,6 +1,3 @@
-# type alias to make code more readable
-Scalar = Union{Number,CategoricalValue}
-
 # fallback to unary evaluation
 (loss::DistanceLoss)(output::Number, target::Number) = loss(output - target)
 deriv(loss::DistanceLoss, output::Number, target::Number) = deriv(loss, output - target)

--- a/src/losses/other.jl
+++ b/src/losses/other.jl
@@ -17,9 +17,9 @@ MisclassLoss() = MisclassLoss{Float64}()
 deriv(::MisclassLoss{R}, agreement::Bool) where {R} = zero(R)
 deriv2(::MisclassLoss{R}, agreement::Bool) where {R} = zero(R)
 
-(loss::MisclassLoss)(output::Scalar, target::Scalar) = loss(target == output)
-deriv(loss::MisclassLoss, output::Scalar, target::Scalar) = deriv(loss, target == output)
-deriv2(loss::MisclassLoss, output::Scalar, target::Scalar) = deriv2(loss, target == output)
+(loss::MisclassLoss)(output::Number, target::Number) = loss(target == output)
+deriv(loss::MisclassLoss, output::Number, target::Number) = deriv(loss, target == output)
+deriv2(loss::MisclassLoss, output::Number, target::Number) = deriv2(loss, target == output)
 
 isminimizable(::MisclassLoss) = false
 isdifferentiable(::MisclassLoss) = false


### PR DESCRIPTION
Fixes #167. This should be completely backwards compatible. It just decreases load time if the user is not using CategoricalArrays.jl in their application.

Before:

```julia
julia> @time_imports using LossFunctions
      1.6 ms  DataAPI
      8.1 ms  Missings
      1.0 ms  Statistics
     62.9 ms  CategoricalArrays
    108.0 ms  LossFunctions
```

After:

```julia
julia> @time_imports using LossFunctions
      0.9 ms  Statistics
      0.4 ms  Requires
      4.0 ms  LossFunctions
```