### PR TITLE
fix: load Requires.jl only if needed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LossFunctions"
 uuid = "30fc2ffe-d236-52d8-8643-a9d8f7c094a7"
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"

--- a/src/LossFunctions.jl
+++ b/src/LossFunctions.jl
@@ -8,7 +8,10 @@ using Markdown
 
 import Base: sum
 import Statistics: mean
-import Requires: @init, @require
+
+if !isdefined(Base, :get_extension)
+  import Requires: @require
+end
 
 # trait functions
 include("traits.jl")
@@ -20,10 +23,12 @@ include("losses.jl")
 include("io.jl")
 
 # Extensions
-if !isdefined(Base, :get_extension)
-  @init @require CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597" include(
-    "../ext/LossFunctionsCategoricalArraysExt.jl"
-  )
+@static if !isdefined(Base, :get_extension)
+  function __init__()
+    @require CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597" include(
+      "../ext/LossFunctionsCategoricalArraysExt.jl"
+    )
+  end
 end
 
 export


### PR DESCRIPTION
### Previous 

```julia
julia> @time_imports using LossFunctions
               ┌ 0.0 ms Requires.__init__() 
    173.5 ms  Requires 99.67% compilation time
      4.0 ms  LossFunctions
```

### Current

```julia
julia> @time_imports using LossFunctions
      3.5 ms  LossFunctions
```
